### PR TITLE
fix(docker): resolve container startup issues for local dev

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,6 @@ cryptography==42.0.5
 httpx==0.27.0
 python-multipart==0.0.9
 pytest==8.0.0
-pytest-asyncio==0.23.4
+pytest-asyncio==0.23.8
 pytest-cov==4.1.0
 ruff==0.2.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - ./frontend/src:/app/src
       - ./frontend/public:/app/public
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000"]
       interval: 15s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Upgrade `pytest-asyncio` from `0.23.4` → `0.23.8` to fix incompatibility with `pytest==8.0.0`
- Fix frontend healthcheck: `localhost` resolves to IPv6 `[::1]` on Alpine but Vite listens on IPv4 — changed to `127.0.0.1`

## Test plan
- [x] `finza-backend` healthy — smoke test `GET /api/v1/health` returns 200
- [x] `finza-frontend` healthy — healthcheck passes on `127.0.0.1:3000`
- [x] `finza-nginx` healthy — `GET http://localhost/` returns 200
- [x] All 3 containers up simultaneously with `docker-compose up --build -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)