### PR TITLE
feat(backend): loans CRUD with partial payments — closes #38 #39

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -5,6 +5,7 @@ from app.api.v1.routes.dashboard import router as dashboard_router
 from app.api.v1.routes.egresos import router as egresos_router
 from app.api.v1.routes.health import router as health_router
 from app.api.v1.routes.ingresos import router as ingresos_router
+from app.api.v1.routes.prestamos import router as prestamos_router
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
@@ -12,3 +13,4 @@ api_router.include_router(categorias_router)
 api_router.include_router(ingresos_router)
 api_router.include_router(egresos_router)
 api_router.include_router(dashboard_router)
+api_router.include_router(prestamos_router)

--- a/backend/app/api/v1/routes/prestamos.py
+++ b/backend/app/api/v1/routes/prestamos.py
@@ -1,0 +1,155 @@
+from datetime import date
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.prestamo import (
+    PagoPrestamoCreate,
+    PagoPrestamoResponse,
+    PrestamoCreate,
+    PrestamoResumen,
+    PrestamoResponse,
+    PrestamoUpdate,
+)
+from app.services import prestamos as svc
+
+router = APIRouter(prefix="/prestamos", tags=["prestamos"])
+
+
+@router.get("", response_model=list[PrestamoResponse])
+async def list_prestamos(
+    tipo: str | None = Query(None, description="Filtrar por tipo: me_deben o yo_debo"),
+    estado: str | None = Query(
+        None, description="Filtrar por estado: activo, pagado, vencido"
+    ),
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.get_prestamos(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        tipo=tipo,
+        estado=estado,
+    )
+
+
+@router.post("", response_model=PrestamoResponse, status_code=201)
+async def create_prestamo(
+    data: PrestamoCreate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    result = svc.create_prestamo(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        data=data,
+    )
+    result.setdefault("pagos", [])
+    return result
+
+
+@router.get("/resumen", response_model=PrestamoResumen)
+async def get_resumen(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.get_resumen(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+    )
+
+
+@router.get("/{prestamo_id}", response_model=PrestamoResponse)
+async def get_prestamo(
+    prestamo_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    result = svc.get_prestamo(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        prestamo_id=str(prestamo_id),
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+    return result
+
+
+@router.put("/{prestamo_id}", response_model=PrestamoResponse)
+async def update_prestamo(
+    prestamo_id: UUID,
+    data: PrestamoUpdate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    result = svc.update_prestamo(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        prestamo_id=str(prestamo_id),
+        data=data,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+    result.setdefault("pagos", [])
+    return result
+
+
+@router.delete("/{prestamo_id}", status_code=204)
+async def delete_prestamo(
+    prestamo_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    svc.delete_prestamo(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        prestamo_id=str(prestamo_id),
+    )
+
+
+@router.get("/{prestamo_id}/pagos", response_model=list[PagoPrestamoResponse])
+async def list_pagos(
+    prestamo_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.get_pagos(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        prestamo_id=str(prestamo_id),
+    )
+
+
+@router.post(
+    "/{prestamo_id}/pagos",
+    response_model=dict,
+    status_code=201,
+)
+async def registrar_pago(
+    prestamo_id: UUID,
+    data: PagoPrestamoCreate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.registrar_pago(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        prestamo_id=str(prestamo_id),
+        data=data,
+    )
+
+
+@router.delete("/{prestamo_id}/pagos/{pago_id}", status_code=204)
+async def delete_pago(
+    prestamo_id: UUID,
+    pago_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    svc.delete_pago(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        prestamo_id=str(prestamo_id),
+        pago_id=str(pago_id),
+    )

--- a/backend/app/schemas/prestamo.py
+++ b/backend/app/schemas/prestamo.py
@@ -1,0 +1,118 @@
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, computed_field, field_validator
+
+
+TipoPrestamo = Literal["me_deben", "yo_debo"]
+EstadoPrestamo = Literal["activo", "pagado", "vencido"]
+
+
+class PrestamoCreate(BaseModel):
+    tipo: TipoPrestamo
+    persona: str
+    monto_original: Decimal
+    moneda: str = "DOP"
+    fecha_prestamo: date
+    fecha_vencimiento: date | None = None
+    descripcion: str | None = None
+    notas: str | None = None
+
+    @field_validator("monto_original")
+    @classmethod
+    def monto_must_be_positive(cls, v: Decimal) -> Decimal:
+        if v <= 0:
+            raise ValueError("El monto debe ser mayor a 0.")
+        return v
+
+    @field_validator("persona")
+    @classmethod
+    def persona_must_not_be_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("El nombre de la persona no puede estar vacio.")
+        return v.strip()
+
+
+class PrestamoUpdate(BaseModel):
+    persona: str | None = None
+    fecha_vencimiento: date | None = None
+    descripcion: str | None = None
+    notas: str | None = None
+    estado: EstadoPrestamo | None = None
+
+    @field_validator("persona")
+    @classmethod
+    def persona_must_not_be_empty(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("El nombre de la persona no puede estar vacio.")
+        return v.strip() if v else v
+
+
+class PagoPrestamoCreate(BaseModel):
+    monto: Decimal
+    fecha: date
+    notas: str | None = None
+
+    @field_validator("monto")
+    @classmethod
+    def monto_must_be_positive(cls, v: Decimal) -> Decimal:
+        if v <= 0:
+            raise ValueError("El monto debe ser mayor a 0.")
+        return v
+
+
+class PagoPrestamoResponse(BaseModel):
+    id: uuid.UUID
+    prestamo_id: uuid.UUID
+    user_id: uuid.UUID
+    monto: Decimal
+    fecha: date
+    notas: str | None
+    created_at: datetime
+    deleted_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PrestamoResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    tipo: str
+    persona: str
+    monto_original: Decimal
+    monto_pendiente: Decimal
+    moneda: str
+    fecha_prestamo: date
+    fecha_vencimiento: date | None
+    descripcion: str | None
+    estado: str
+    notas: str | None
+    created_at: datetime
+    updated_at: datetime
+    pagos: list[PagoPrestamoResponse] = []
+
+    @computed_field
+    @property
+    def porcentaje_pagado(self) -> float:
+        if self.monto_original == 0:
+            return 0.0
+        pagado = self.monto_original - self.monto_pendiente
+        return round(float(pagado / self.monto_original) * 100, 2)
+
+    model_config = {"from_attributes": True}
+
+
+class PrestamoResumenTipo(BaseModel):
+    cantidad: int
+    monto_original_total: Decimal
+    monto_pendiente_total: Decimal
+
+
+class PrestamoResumen(BaseModel):
+    me_deben: PrestamoResumenTipo
+    yo_debo: PrestamoResumenTipo
+    total_activos: int
+    total_pagados: int
+    total_vencidos: int

--- a/backend/app/services/base.py
+++ b/backend/app/services/base.py
@@ -1,0 +1,27 @@
+from fastapi import HTTPException
+from postgrest import APIError
+
+
+def _handle_api_error(e: APIError) -> None:
+    """Translate a PostgREST APIError into an appropriate HTTPException.
+
+    Handles Postgres SQLSTATE codes and HTTP-style numeric codes returned
+    by Supabase PostgREST.
+    """
+    code = e.code or ""
+    # Postgres SQLSTATE: 23505 = unique_violation, 23503 = foreign_key_violation
+    if code == "23505":
+        raise HTTPException(status_code=409, detail=str(e.message))
+    if code == "23503":
+        raise HTTPException(status_code=400, detail=str(e.message))
+    try:
+        status = int(code)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=500, detail="Error interno del servidor.")
+    if status == 400:
+        raise HTTPException(status_code=400, detail=str(e.message))
+    if status == 404:
+        raise HTTPException(status_code=404, detail=str(e.message))
+    if status == 409:
+        raise HTTPException(status_code=409, detail=str(e.message))
+    raise HTTPException(status_code=500, detail="Error interno del servidor.")

--- a/backend/app/services/egresos.py
+++ b/backend/app/services/egresos.py
@@ -4,26 +4,7 @@ from fastapi import HTTPException
 from postgrest import APIError
 
 from app.core.supabase_client import get_user_client
-
-
-def _handle_api_error(e: APIError) -> None:
-    code = e.code or ""
-    # Postgres SQLSTATE: 23505 = unique_violation, 23503 = foreign_key_violation
-    if code == "23505":
-        raise HTTPException(status_code=409, detail=str(e.message))
-    if code == "23503":
-        raise HTTPException(status_code=400, detail=str(e.message))
-    try:
-        status = int(code)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=500, detail="Error interno del servidor.")
-    if status == 400:
-        raise HTTPException(status_code=400, detail=str(e.message))
-    if status == 404:
-        raise HTTPException(status_code=404, detail=str(e.message))
-    if status == 409:
-        raise HTTPException(status_code=409, detail=str(e.message))
-    raise HTTPException(status_code=500, detail="Error interno del servidor.")
+from app.services.base import _handle_api_error
 
 
 def list_egresos(

--- a/backend/app/services/ingresos.py
+++ b/backend/app/services/ingresos.py
@@ -4,26 +4,7 @@ from fastapi import HTTPException
 from postgrest import APIError
 
 from app.core.supabase_client import get_user_client
-
-
-def _handle_api_error(e: APIError) -> None:
-    code = e.code or ""
-    # Postgres SQLSTATE: 23505 = unique_violation, 23503 = foreign_key_violation
-    if code == "23505":
-        raise HTTPException(status_code=409, detail=str(e.message))
-    if code == "23503":
-        raise HTTPException(status_code=400, detail=str(e.message))
-    try:
-        status = int(code)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=500, detail="Error interno del servidor.")
-    if status == 400:
-        raise HTTPException(status_code=400, detail=str(e.message))
-    if status == 404:
-        raise HTTPException(status_code=404, detail=str(e.message))
-    if status == 409:
-        raise HTTPException(status_code=409, detail=str(e.message))
-    raise HTTPException(status_code=500, detail="Error interno del servidor.")
+from app.services.base import _handle_api_error
 
 
 def list_ingresos(

--- a/backend/app/services/prestamos.py
+++ b/backend/app/services/prestamos.py
@@ -1,0 +1,328 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from fastapi import HTTPException
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.schemas.prestamo import PagoPrestamoCreate, PrestamoCreate, PrestamoUpdate
+from app.services.base import _handle_api_error
+
+
+def get_prestamos(
+    user_jwt: str,
+    user_id: str,
+    tipo: str | None = None,
+    estado: str | None = None,
+) -> list[dict]:
+    client = get_user_client(user_jwt)
+    try:
+        query = (
+            client.table("prestamos")
+            .select("*")
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .order("created_at", desc=True)
+        )
+        if tipo:
+            query = query.eq("tipo", tipo)
+        if estado:
+            query = query.eq("estado", estado)
+
+        response = query.execute()
+        return response.data
+    except APIError as e:
+        _handle_api_error(e)
+    return []
+
+
+def create_prestamo(user_jwt: str, user_id: str, data: PrestamoCreate) -> dict:
+    client = get_user_client(user_jwt)
+    payload = data.model_dump()
+    payload["user_id"] = user_id
+    payload["monto_pendiente"] = str(payload["monto_original"])
+    payload["monto_original"] = str(payload["monto_original"])
+    payload["fecha_prestamo"] = str(payload["fecha_prestamo"])
+    if payload.get("fecha_vencimiento"):
+        payload["fecha_vencimiento"] = str(payload["fecha_vencimiento"])
+
+    try:
+        response = client.table("prestamos").insert(payload).execute()
+        return response.data[0]
+    except IndexError:
+        raise HTTPException(
+            status_code=500, detail="Prestamo no encontrado tras insercion."
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def get_prestamo(user_jwt: str, user_id: str, prestamo_id: str) -> dict | None:
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("prestamos")
+            .select("*")
+            .eq("id", prestamo_id)
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .maybe_single()
+            .execute()
+        )
+        if not response.data:
+            return None
+
+        prestamo = response.data
+
+        pagos_response = (
+            client.table("pagos_prestamo")
+            .select("*")
+            .eq("prestamo_id", prestamo_id)
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .order("fecha", desc=True)
+            .execute()
+        )
+        prestamo["pagos"] = pagos_response.data or []
+        return prestamo
+    except APIError as e:
+        _handle_api_error(e)
+    return None
+
+
+def update_prestamo(
+    user_jwt: str, user_id: str, prestamo_id: str, data: PrestamoUpdate
+) -> dict | None:
+    client = get_user_client(user_jwt)
+    payload = data.model_dump(exclude_unset=True)
+
+    if not payload:
+        raise HTTPException(status_code=422, detail="No hay campos para actualizar.")
+
+    if "fecha_vencimiento" in payload and payload["fecha_vencimiento"]:
+        payload["fecha_vencimiento"] = str(payload["fecha_vencimiento"])
+
+    try:
+        response = (
+            client.table("prestamos")
+            .update(payload)
+            .eq("id", prestamo_id)
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .execute()
+        )
+        return response.data[0] if response.data else None
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+    except APIError as e:
+        _handle_api_error(e)
+    return None
+
+
+def delete_prestamo(user_jwt: str, user_id: str, prestamo_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("prestamos")
+            .update({"deleted_at": datetime.now(timezone.utc).isoformat()})
+            .eq("id", prestamo_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+        return response.data[0]
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def get_pagos(
+    user_jwt: str, user_id: str, prestamo_id: str
+) -> list[dict]:
+    client = get_user_client(user_jwt)
+    try:
+        prestamo_check = (
+            client.table("prestamos")
+            .select("id")
+            .eq("id", prestamo_id)
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .maybe_single()
+            .execute()
+        )
+        if not prestamo_check.data:
+            raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+
+        response = (
+            client.table("pagos_prestamo")
+            .select("*")
+            .eq("prestamo_id", prestamo_id)
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .order("fecha", desc=True)
+            .execute()
+        )
+        return response.data
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return []
+
+
+def registrar_pago(
+    user_jwt: str,
+    user_id: str,
+    prestamo_id: str,
+    data: PagoPrestamoCreate,
+) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        result = client.rpc(
+            "registrar_pago_prestamo",
+            {
+                "p_prestamo_id": prestamo_id,
+                "p_user_id": user_id,
+                "p_monto": str(data.monto),
+                "p_fecha": str(data.fecha),
+                "p_notas": data.notas,
+            },
+        ).execute()
+
+        if not result.data:
+            raise HTTPException(
+                status_code=500, detail="Error al registrar el pago."
+            )
+        return result.data
+    except HTTPException:
+        raise
+    except APIError as e:
+        msg = str(e.message) if e.message else ""
+        if "no encontrado" in msg.lower():
+            raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+        if "no esta activo" in msg.lower():
+            raise HTTPException(
+                status_code=400, detail="El prestamo no esta activo."
+            )
+        if "excede el pendiente" in msg.lower():
+            raise HTTPException(
+                status_code=400,
+                detail="El monto del pago excede el monto pendiente.",
+            )
+        _handle_api_error(e)
+    return {}
+
+
+def delete_pago(
+    user_jwt: str, user_id: str, prestamo_id: str, pago_id: str
+) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        pago_response = (
+            client.table("pagos_prestamo")
+            .select("*")
+            .eq("id", pago_id)
+            .eq("prestamo_id", prestamo_id)
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .maybe_single()
+            .execute()
+        )
+        if not pago_response.data:
+            raise HTTPException(status_code=404, detail="Pago no encontrado.")
+
+        pago = pago_response.data
+        monto_pago = Decimal(str(pago["monto"]))
+
+        soft_delete_response = (
+            client.table("pagos_prestamo")
+            .update({"deleted_at": datetime.now(timezone.utc).isoformat()})
+            .eq("id", pago_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+        if not soft_delete_response.data:
+            raise HTTPException(status_code=404, detail="Pago no encontrado.")
+
+        prestamo_response = (
+            client.table("prestamos")
+            .select("monto_pendiente, monto_original, estado")
+            .eq("id", prestamo_id)
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .maybe_single()
+            .execute()
+        )
+        if not prestamo_response.data:
+            raise HTTPException(status_code=404, detail="Prestamo no encontrado.")
+
+        prestamo = prestamo_response.data
+        nuevo_pendiente = Decimal(str(prestamo["monto_pendiente"])) + monto_pago
+        monto_original = Decimal(str(prestamo["monto_original"]))
+
+        if nuevo_pendiente > monto_original:
+            nuevo_pendiente = monto_original
+
+        nuevo_estado = "activo" if nuevo_pendiente > 0 else "pagado"
+
+        client.table("prestamos").update(
+            {
+                "monto_pendiente": str(nuevo_pendiente),
+                "estado": nuevo_estado,
+            }
+        ).eq("id", prestamo_id).eq("user_id", user_id).execute()
+
+        return soft_delete_response.data[0]
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def get_resumen(user_jwt: str, user_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("prestamos")
+            .select("tipo, estado, monto_original, monto_pendiente")
+            .eq("user_id", user_id)
+            .is_("deleted_at", "null")
+            .execute()
+        )
+        prestamos = response.data or []
+
+        me_deben_activos = [
+            p for p in prestamos if p["tipo"] == "me_deben" and p["estado"] == "activo"
+        ]
+        yo_debo_activos = [
+            p for p in prestamos if p["tipo"] == "yo_debo" and p["estado"] == "activo"
+        ]
+        me_deben_todos = [p for p in prestamos if p["tipo"] == "me_deben"]
+        yo_debo_todos = [p for p in prestamos if p["tipo"] == "yo_debo"]
+
+        def sumar(lista: list[dict], campo: str) -> Decimal:
+            return sum(Decimal(str(p[campo])) for p in lista)
+
+        return {
+            "me_deben": {
+                "cantidad": len(me_deben_todos),
+                "monto_original_total": str(sumar(me_deben_todos, "monto_original")),
+                "monto_pendiente_total": str(sumar(me_deben_activos, "monto_pendiente")),
+            },
+            "yo_debo": {
+                "cantidad": len(yo_debo_todos),
+                "monto_original_total": str(sumar(yo_debo_todos, "monto_original")),
+                "monto_pendiente_total": str(sumar(yo_debo_activos, "monto_pendiente")),
+            },
+            "total_activos": sum(1 for p in prestamos if p["estado"] == "activo"),
+            "total_pagados": sum(1 for p in prestamos if p["estado"] == "pagado"),
+            "total_vencidos": sum(1 for p in prestamos if p["estado"] == "vencido"),
+        }
+    except APIError as e:
+        _handle_api_error(e)
+    return {}

--- a/backend/tests/test_prestamos.py
+++ b/backend/tests/test_prestamos.py
@@ -1,0 +1,431 @@
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from postgrest import APIError
+
+
+# ---------------------------------------------------------------------------
+# Auth guard tests — no token → 403
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_prestamos_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/prestamos")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_prestamo_requires_auth(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/v1/prestamos",
+        json={
+            "tipo": "me_deben",
+            "persona": "Juan",
+            "monto_original": "1000.00",
+            "fecha_prestamo": "2026-03-09",
+        },
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_resumen_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/prestamos/resumen")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_prestamo_by_id_requires_auth(client: AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/prestamos/00000000-0000-0000-0000-000000000001"
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_prestamo_requires_auth(client: AsyncClient) -> None:
+    response = await client.delete(
+        "/api/v1/prestamos/00000000-0000-0000-0000-000000000001"
+    )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Service unit tests — mock supabase client
+# ---------------------------------------------------------------------------
+
+
+def test_create_prestamo_me_deben_sets_monto_pendiente():
+    """Creating a me_deben loan sets monto_pendiente equal to monto_original."""
+    from app.schemas.prestamo import PrestamoCreate
+    from app.services.prestamos import create_prestamo
+
+    inserted_row = {
+        "id": "aaaa-1111",
+        "user_id": "u1",
+        "tipo": "me_deben",
+        "persona": "Ana",
+        "monto_original": "500.00",
+        "monto_pendiente": "500.00",
+        "moneda": "DOP",
+        "fecha_prestamo": "2026-03-09",
+        "fecha_vencimiento": None,
+        "descripcion": None,
+        "estado": "activo",
+        "notas": None,
+        "created_at": "2026-03-09T00:00:00+00:00",
+        "updated_at": "2026-03-09T00:00:00+00:00",
+        "deleted_at": None,
+    }
+    mock_response = MagicMock()
+    mock_response.data = [inserted_row]
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.return_value = (
+        mock_response
+    )
+
+    data = PrestamoCreate(
+        tipo="me_deben",
+        persona="Ana",
+        monto_original=Decimal("500.00"),
+        fecha_prestamo="2026-03-09",
+    )
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = create_prestamo("fake-jwt", "u1", data)
+
+    assert result["id"] == "aaaa-1111"
+    insert_payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert insert_payload["user_id"] == "u1"
+    assert insert_payload["tipo"] == "me_deben"
+    # monto_pendiente debe ser igual a monto_original al crear
+    assert insert_payload["monto_pendiente"] == insert_payload["monto_original"]
+
+
+def test_create_prestamo_yo_debo():
+    """Creating a yo_debo loan works the same as me_deben."""
+    from app.schemas.prestamo import PrestamoCreate
+    from app.services.prestamos import create_prestamo
+
+    inserted_row = {
+        "id": "bbbb-2222",
+        "user_id": "u1",
+        "tipo": "yo_debo",
+        "persona": "Pedro",
+        "monto_original": "2000.00",
+        "monto_pendiente": "2000.00",
+        "moneda": "DOP",
+        "fecha_prestamo": "2026-03-09",
+        "fecha_vencimiento": None,
+        "descripcion": None,
+        "estado": "activo",
+        "notas": None,
+        "created_at": "2026-03-09T00:00:00+00:00",
+        "updated_at": "2026-03-09T00:00:00+00:00",
+        "deleted_at": None,
+    }
+    mock_response = MagicMock()
+    mock_response.data = [inserted_row]
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.return_value = (
+        mock_response
+    )
+
+    data = PrestamoCreate(
+        tipo="yo_debo",
+        persona="Pedro",
+        monto_original=Decimal("2000.00"),
+        fecha_prestamo="2026-03-09",
+    )
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = create_prestamo("fake-jwt", "u1", data)
+
+    assert result["tipo"] == "yo_debo"
+    insert_payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert insert_payload["tipo"] == "yo_debo"
+    assert insert_payload["monto_pendiente"] == insert_payload["monto_original"]
+
+
+def test_get_prestamo_not_found_returns_none():
+    """get_prestamo returns None when the record does not exist."""
+    from app.services.prestamos import get_prestamo
+
+    mock_response = MagicMock()
+    mock_response.data = None
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.is_.return_value.maybe_single.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = get_prestamo("fake-jwt", "u1", "nonexistent-id")
+
+    assert result is None
+
+
+def test_registrar_pago_parcial_reduces_monto_pendiente():
+    """registrar_pago via RPC returns reduced monto_pendiente for a partial payment."""
+    from app.schemas.prestamo import PagoPrestamoCreate
+    from app.services.prestamos import registrar_pago
+
+    rpc_result = {
+        "pago_id": "cccc-3333",
+        "monto_pendiente": 700.00,
+        "estado": "activo",
+    }
+    mock_response = MagicMock()
+    mock_response.data = rpc_result
+
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.return_value = mock_response
+
+    data = PagoPrestamoCreate(monto=Decimal("300.00"), fecha="2026-03-09")
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = registrar_pago("fake-jwt", "u1", "prestamo-id-1", data)
+
+    assert result["monto_pendiente"] == 700.00
+    assert result["estado"] == "activo"
+    # Verify RPC was called with correct function name
+    mock_client.rpc.assert_called_once_with(
+        "registrar_pago_prestamo",
+        {
+            "p_prestamo_id": "prestamo-id-1",
+            "p_user_id": "u1",
+            "p_monto": "300.00",
+            "p_fecha": "2026-03-09",
+            "p_notas": None,
+        },
+    )
+
+
+def test_registrar_pago_completo_estado_pagado():
+    """registrar_pago returns estado=pagado when monto equals monto_pendiente."""
+    from app.schemas.prestamo import PagoPrestamoCreate
+    from app.services.prestamos import registrar_pago
+
+    rpc_result = {
+        "pago_id": "dddd-4444",
+        "monto_pendiente": 0.00,
+        "estado": "pagado",
+    }
+    mock_response = MagicMock()
+    mock_response.data = rpc_result
+
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.return_value = mock_response
+
+    data = PagoPrestamoCreate(monto=Decimal("1000.00"), fecha="2026-03-09")
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = registrar_pago("fake-jwt", "u1", "prestamo-id-2", data)
+
+    assert result["monto_pendiente"] == 0.00
+    assert result["estado"] == "pagado"
+
+
+def test_registrar_pago_excede_pendiente_raises_400():
+    """registrar_pago raises 400 when the RPC signals monto exceeds monto_pendiente."""
+    from app.schemas.prestamo import PagoPrestamoCreate
+    from app.services.prestamos import registrar_pago
+
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.side_effect = APIError(
+        {"code": "P0001", "message": "Monto (500) excede el pendiente (300)"}
+    )
+
+    data = PagoPrestamoCreate(monto=Decimal("500.00"), fecha="2026-03-09")
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            registrar_pago("fake-jwt", "u1", "prestamo-id-3", data)
+
+    assert exc_info.value.status_code == 400
+    assert "excede" in exc_info.value.detail.lower()
+
+
+def test_get_resumen_estructura():
+    """get_resumen returns the expected PrestamoResumen structure."""
+    from app.services.prestamos import get_resumen
+
+    prestamos_data = [
+        {
+            "tipo": "me_deben",
+            "estado": "activo",
+            "monto_original": "1000.00",
+            "monto_pendiente": "700.00",
+        },
+        {
+            "tipo": "me_deben",
+            "estado": "pagado",
+            "monto_original": "500.00",
+            "monto_pendiente": "0.00",
+        },
+        {
+            "tipo": "yo_debo",
+            "estado": "activo",
+            "monto_original": "2000.00",
+            "monto_pendiente": "2000.00",
+        },
+        {
+            "tipo": "yo_debo",
+            "estado": "vencido",
+            "monto_original": "300.00",
+            "monto_pendiente": "300.00",
+        },
+    ]
+
+    mock_response = MagicMock()
+    mock_response.data = prestamos_data
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.is_.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = get_resumen("fake-jwt", "u1")
+
+    # Estructura base
+    assert "me_deben" in result
+    assert "yo_debo" in result
+    assert "total_activos" in result
+    assert "total_pagados" in result
+    assert "total_vencidos" in result
+
+    # Conteos por estado
+    assert result["total_activos"] == 2   # 1 me_deben activo + 1 yo_debo activo
+    assert result["total_pagados"] == 1   # 1 me_deben pagado
+    assert result["total_vencidos"] == 1  # 1 yo_debo vencido
+
+    # me_deben: 2 en total (activo + pagado)
+    assert result["me_deben"]["cantidad"] == 2
+    assert Decimal(result["me_deben"]["monto_original_total"]) == Decimal("1500.00")
+    # monto_pendiente_total solo cuenta activos
+    assert Decimal(result["me_deben"]["monto_pendiente_total"]) == Decimal("700.00")
+
+    # yo_debo: 2 en total (activo + vencido)
+    assert result["yo_debo"]["cantidad"] == 2
+    assert Decimal(result["yo_debo"]["monto_original_total"]) == Decimal("2300.00")
+    # monto_pendiente_total solo cuenta activos
+    assert Decimal(result["yo_debo"]["monto_pendiente_total"]) == Decimal("2000.00")
+
+
+def test_delete_prestamo_soft_delete():
+    """delete_prestamo sets deleted_at and does not raise when record exists."""
+    from app.services.prestamos import delete_prestamo
+
+    mock_response = MagicMock()
+    mock_response.data = [
+        {"id": "eeee-5555", "deleted_at": "2026-03-09T00:00:00+00:00"}
+    ]
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = delete_prestamo("fake-jwt", "u1", "eeee-5555")
+
+    assert result["id"] == "eeee-5555"
+    assert "deleted_at" in result
+    update_payload = mock_client.table.return_value.update.call_args[0][0]
+    assert "deleted_at" in update_payload
+
+
+def test_delete_prestamo_not_found_raises_404():
+    """delete_prestamo raises 404 when no rows are updated (record not found)."""
+    from app.services.prestamos import delete_prestamo
+
+    mock_response = MagicMock()
+    mock_response.data = []  # empty = not found
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            delete_prestamo("fake-jwt", "u1", "nonexistent-id")
+
+    assert exc_info.value.status_code == 404
+
+
+def test_get_prestamos_list_returns_items():
+    """get_prestamos returns a list of loans for the user."""
+    from app.services.prestamos import get_prestamos
+
+    prestamos_data = [
+        {
+            "id": "ffff-6666",
+            "user_id": "u1",
+            "tipo": "me_deben",
+            "persona": "Carlos",
+            "monto_original": "800.00",
+            "monto_pendiente": "800.00",
+            "estado": "activo",
+        }
+    ]
+    mock_response = MagicMock()
+    mock_response.data = prestamos_data
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.is_.return_value.order.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        result = get_prestamos("fake-jwt", "u1")
+
+    assert len(result) == 1
+    assert result[0]["id"] == "ffff-6666"
+
+
+def test_get_prestamos_api_error_raises_500():
+    """get_prestamos raises HTTP 500 on unexpected Supabase APIError."""
+    from app.services.prestamos import get_prestamos
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.is_.return_value.order.return_value.execute.side_effect
+    ) = APIError({"code": "503", "message": "Service unavailable"})
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            get_prestamos("fake-jwt", "u1")
+
+    assert exc_info.value.status_code == 500
+
+
+def test_create_prestamo_api_error_raises_http():
+    """create_prestamo propagates APIError as HTTPException."""
+    from app.schemas.prestamo import PrestamoCreate
+    from app.services.prestamos import create_prestamo
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.side_effect = APIError(
+        {"code": "400", "message": "Bad request"}
+    )
+
+    data = PrestamoCreate(
+        tipo="me_deben",
+        persona="Test",
+        monto_original=Decimal("100.00"),
+        fecha_prestamo="2026-03-09",
+    )
+
+    with patch("app.services.prestamos.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            create_prestamo("fake-jwt", "u1", data)
+
+    assert exc_info.value.status_code == 400

--- a/supabase/migrations/20260309000001_prestamos_pagos.sql
+++ b/supabase/migrations/20260309000001_prestamos_pagos.sql
@@ -1,0 +1,115 @@
+-- Wave 5a: Prestamos y pagos
+-- Issue #38
+
+-- Enums
+CREATE TYPE tipo_prestamo AS ENUM ('me_deben', 'yo_debo');
+CREATE TYPE estado_prestamo AS ENUM ('activo', 'pagado', 'vencido');
+
+-- Tabla prestamos
+CREATE TABLE IF NOT EXISTS prestamos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    tipo tipo_prestamo NOT NULL,
+    persona TEXT NOT NULL,
+    monto_original NUMERIC(15,2) NOT NULL CHECK (monto_original > 0),
+    monto_pendiente NUMERIC(15,2) NOT NULL CHECK (monto_pendiente >= 0),
+    moneda TEXT NOT NULL DEFAULT 'DOP',
+    fecha_prestamo DATE NOT NULL,
+    fecha_vencimiento DATE,
+    descripcion TEXT,
+    estado estado_prestamo NOT NULL DEFAULT 'activo',
+    notas TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at TIMESTAMPTZ
+);
+
+-- Tabla pagos_prestamo
+CREATE TABLE IF NOT EXISTS pagos_prestamo (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    prestamo_id UUID NOT NULL REFERENCES prestamos(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    monto NUMERIC(15,2) NOT NULL CHECK (monto > 0),
+    fecha DATE NOT NULL,
+    notas TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at TIMESTAMPTZ
+);
+
+-- Indices
+CREATE INDEX IF NOT EXISTS idx_prestamos_user_id ON prestamos(user_id);
+CREATE INDEX IF NOT EXISTS idx_prestamos_estado ON prestamos(estado);
+CREATE INDEX IF NOT EXISTS idx_prestamos_tipo ON prestamos(tipo);
+CREATE INDEX IF NOT EXISTS idx_pagos_prestamo_id ON pagos_prestamo(prestamo_id);
+
+-- Trigger updated_at (la funcion update_updated_at_column ya existe desde la migracion inicial)
+CREATE TRIGGER update_prestamos_updated_at BEFORE UPDATE ON prestamos
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- RLS
+ALTER TABLE prestamos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE pagos_prestamo ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "prestamos_select_own" ON prestamos FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "prestamos_insert_own" ON prestamos FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "prestamos_update_own" ON prestamos FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "prestamos_delete_own" ON prestamos FOR DELETE USING (auth.uid() = user_id);
+
+CREATE POLICY "pagos_prestamo_select_own" ON pagos_prestamo FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "pagos_prestamo_insert_own" ON pagos_prestamo FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "pagos_prestamo_delete_own" ON pagos_prestamo FOR DELETE USING (auth.uid() = user_id);
+
+-- RPC atomica para registrar pago
+-- Usa SECURITY DEFINER para que la funcion se ejecute con permisos del owner (superuser),
+-- lo que permite la operacion atomica UPDATE + INSERT sin depender de RLS durante la transaccion.
+-- La validacion de ownership se hace explicitamente via WHERE user_id = p_user_id.
+CREATE OR REPLACE FUNCTION registrar_pago_prestamo(
+    p_prestamo_id UUID,
+    p_user_id UUID,
+    p_monto NUMERIC,
+    p_fecha DATE,
+    p_notas TEXT DEFAULT NULL
+) RETURNS JSON AS $$
+DECLARE
+    v_prestamo RECORD;
+    v_nuevo_pendiente NUMERIC(15,2);
+    v_nuevo_estado estado_prestamo;
+    v_pago_id UUID;
+BEGIN
+    SELECT * INTO v_prestamo FROM prestamos
+    WHERE id = p_prestamo_id AND user_id = p_user_id AND deleted_at IS NULL
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Prestamo no encontrado';
+    END IF;
+    IF v_prestamo.estado != 'activo' THEN
+        RAISE EXCEPTION 'Prestamo no esta activo (estado: %)', v_prestamo.estado;
+    END IF;
+    IF p_monto > v_prestamo.monto_pendiente THEN
+        RAISE EXCEPTION 'Monto (%) excede el pendiente (%)', p_monto, v_prestamo.monto_pendiente;
+    END IF;
+
+    v_nuevo_pendiente := v_prestamo.monto_pendiente - p_monto;
+    v_nuevo_estado := CASE
+        WHEN v_nuevo_pendiente = 0 THEN 'pagado'::estado_prestamo
+        ELSE 'activo'::estado_prestamo
+    END;
+
+    INSERT INTO pagos_prestamo (prestamo_id, user_id, monto, fecha, notas)
+    VALUES (p_prestamo_id, p_user_id, p_monto, p_fecha, p_notas)
+    RETURNING id INTO v_pago_id;
+
+    UPDATE prestamos
+    SET monto_pendiente = v_nuevo_pendiente,
+        estado = v_nuevo_estado,
+        updated_at = now()
+    WHERE id = p_prestamo_id;
+
+    RETURN json_build_object(
+        'pago_id', v_pago_id,
+        'monto_pendiente', v_nuevo_pendiente,
+        'estado', v_nuevo_estado
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary

- **#38** — Supabase migration: tablas `prestamos` y `pagos_prestamo` con enums, RLS, índices y RPC atómica `registrar_pago_prestamo()`
- **#39** — Backend completo para préstamos: schemas, service con 9 funciones, router con 9 endpoints, tests unitarios
- Extrae `_handle_api_error` a `services/base.py` eliminando duplicación entre `ingresos.py` y `egresos.py`

## Changes

- `supabase/migrations/20260309000001_prestamos_pagos.sql` — migración con enums `tipo_prestamo`/`estado_prestamo`, tablas, índices, trigger updated_at, políticas RLS y función RPC SECURITY DEFINER
- `backend/app/services/base.py` — `_handle_api_error` compartido para todos los servicios
- `backend/app/services/ingresos.py` + `egresos.py` — importan `_handle_api_error` desde base
- `backend/app/schemas/prestamo.py` — PrestamoCreate, PrestamoUpdate, PrestamoResponse (con `porcentaje_pagado` computed), PagoPrestamoCreate, PagoPrestamoResponse, PrestamoResumen
- `backend/app/services/prestamos.py` — get_prestamos, create_prestamo, get_prestamo (incluye pagos), update_prestamo, delete_prestamo, get_pagos, registrar_pago (RPC), delete_pago (soft + restaura monto), get_resumen
- `backend/app/api/v1/routes/prestamos.py` — 9 endpoints con GET /resumen antes de GET /{id} para evitar conflicto de path
- `backend/app/api/v1/router.py` — registra prestamos_router

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | /prestamos | Lista con filtros tipo/estado |
| POST | /prestamos | Crear préstamo (monto_pendiente = monto_original) |
| GET | /prestamos/resumen | KPIs agrupados por tipo y estado |
| GET | /prestamos/{id} | Detalle con pagos incluidos |
| PUT | /prestamos/{id} | Actualizar (no permite modificar monto_pendiente) |
| DELETE | /prestamos/{id} | Soft delete |
| GET | /prestamos/{id}/pagos | Lista de pagos activos |
| POST | /prestamos/{id}/pagos | Registrar pago via RPC atómica |
| DELETE | /prestamos/{id}/pagos/{pago_id} | Soft delete pago + restaurar monto_pendiente |

## Tests

- 17 tests en `backend/tests/test_prestamos.py`
- 12 sync passing localmente, 5 async se ejecutan en CI (Python 3.11 + pytest-asyncio)
- Cubren: auth guard (403), create me_deben/yo_debo, get not found (404), pago parcial, pago completo, pago que excede pendiente (400), resumen estructura, soft delete, API error (500)

## Test plan

- [ ] `docker exec finza-backend pytest tests/test_prestamos.py -v` — todos pasan
- [ ] `docker exec finza-backend pytest tests/ -v` — suite completa sin regresiones
- [ ] CI workflow verde

Closes #38
Closes #39