### PR TITLE
fix(auth): JWT leeway for Docker clock drift + login race condition

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,5 @@
 import json
+from datetime import timedelta
 from functools import lru_cache
 
 import httpx
@@ -7,6 +8,11 @@ from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.core.config import settings
+
+# Allow up to 60 seconds of clock skew between Docker container and Supabase servers.
+# Docker containers can drift relative to the host clock, causing ImmatureSignatureError
+# when iat/nbf in the JWT is slightly ahead of the container's local clock.
+JWT_LEEWAY = timedelta(seconds=60)
 
 security_scheme = HTTPBearer()
 
@@ -47,6 +53,7 @@ async def get_current_user(
                 settings.JWT_SECRET,
                 algorithms=["HS256"],
                 audience="authenticated",
+                leeway=JWT_LEEWAY,
             )
         else:
             # Current Supabase: ECC P-256 / ES256 — verified via public JWKS
@@ -56,6 +63,7 @@ async def get_current_user(
                 public_key,
                 algorithms=["ES256"],
                 audience="authenticated",
+                leeway=JWT_LEEWAY,
             )
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Token expirado.")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,8 +26,21 @@ export function App(): JSX.Element {
 
   useEffect(() => {
     let cleanup: (() => void) | undefined
-    initialize().then((fn) => { cleanup = fn })
-    return () => { cleanup?.() }
+    let cancelled = false
+
+    initialize().then((fn) => {
+      if (cancelled) {
+        // Strict Mode unmounted before promise resolved — unsubscribe immediately
+        fn()
+      } else {
+        cleanup = fn
+      }
+    })
+
+    return () => {
+      cancelled = true
+      cleanup?.()
+    }
   }, [initialize])
 
   return (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { supabase } from '@/lib/supabase'
+import { useAuthStore } from '@/store/authStore'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { APP_NAME, APP_TAGLINE } from '@/lib/constants'
@@ -17,7 +18,15 @@ type LoginForm = z.infer<typeof loginSchema>
 
 export function LoginPage(): JSX.Element {
   const navigate = useNavigate()
+  const { session, isLoading, setSession } = useAuthStore()
   const [serverError, setServerError] = useState<string | null>(null)
+
+  // Redirect already-authenticated users away from login
+  useEffect(() => {
+    if (!isLoading && session) {
+      navigate('/', { replace: true })
+    }
+  }, [session, isLoading, navigate])
 
   const {
     register,
@@ -27,7 +36,7 @@ export function LoginPage(): JSX.Element {
 
   const onSubmit = async (data: LoginForm): Promise<void> => {
     setServerError(null)
-    const { error } = await supabase.auth.signInWithPassword({
+    const { data: authData, error } = await supabase.auth.signInWithPassword({
       email: data.email,
       password: data.password,
     })
@@ -37,7 +46,17 @@ export function LoginPage(): JSX.Element {
       return
     }
 
+    // Explicitly update store before navigating to avoid race condition
+    // where ProtectedRoute renders before onAuthStateChange fires
+    if (authData.session) {
+      setSession(authData.session)
+    }
     navigate('/')
+  }
+
+  // Don't render form if already authenticated (handles redirect)
+  if (!isLoading && session) {
+    return <Navigate to="/" replace />
   }
 
   return (


### PR DESCRIPTION
## Problema

Al iniciar sesión con un usuario recién registrado, el backend respondía **401 Unauthorized** con el error `ImmatureSignatureError: The token is not yet valid (iat)`. El dashboard aparecía brevemente y volvía a redirigir al login.

## Causa raíz

1. **Clock drift de Docker**: El reloj del container backend va ligeramente retrasado respecto al servidor de Supabase. PyJWT 2.8.0 valida el claim `iat` estrictamente, rechazando tokens cuyo `iat > container_now`.
2. **Race condition en LoginPage**: `navigate('/')` se llamaba antes de que `onAuthStateChange` actualizara el store. `ProtectedRoute` renderizaba con `session: null` y redirigía de vuelta a `/login`.
3. **Fuga de suscripción en App.tsx**: React 18 Strict Mode ejecuta cleanup antes de que la promise de `initialize()` resuelva, dejando dos suscripciones `onAuthStateChange` activas.

## Fixes

### `backend/app/core/security.py`
- Añade `JWT_LEEWAY = timedelta(seconds=60)` y `leeway=JWT_LEEWAY` en ambas llamadas a `jwt.decode()` — tolera hasta 60 segundos de desfase de reloj.

### `frontend/src/pages/LoginPage.tsx`
- Llama `setSession(authData.session)` explícitamente **antes** de `navigate('/')` para eliminar la race condition.
- Añade guard `useEffect` + `<Navigate>` para usuarios ya autenticados que lleguen al login.

### `frontend/src/App.tsx`
- Añade flag `cancelled` para que si React 18 Strict Mode hace unmount antes de que la promise resuelva, el unsubscribe se llame de inmediato (evita doble suscripción).

## Test plan
- [x] Login con usuario registrado → entra al dashboard sin redirigir de vuelta
- [x] Refrescar página estando autenticado → permanece en el dashboard
- [x] Navegar a `/login` estando autenticado → redirige automáticamente a `/`
- [x] Token expirado → 401 correcto con mensaje "Token expirado."
- [x] Backend unit tests: 116/116 passing
- [x] Frontend unit tests: 36/36 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)