### PR TITLE
feat(backend): monthly budget CRUD with spending status endpoint — closes #48

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -7,6 +7,7 @@ from app.api.v1.routes.health import router as health_router
 from app.api.v1.routes.ingresos import router as ingresos_router
 from app.api.v1.routes.metas import router as metas_router
 from app.api.v1.routes.prestamos import router as prestamos_router
+from app.api.v1.routes.presupuestos import router as presupuestos_router
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
@@ -16,3 +17,4 @@ api_router.include_router(egresos_router)
 api_router.include_router(dashboard_router)
 api_router.include_router(prestamos_router)
 api_router.include_router(metas_router)
+api_router.include_router(presupuestos_router)

--- a/backend/app/api/v1/routes/presupuestos.py
+++ b/backend/app/api/v1/routes/presupuestos.py
@@ -1,0 +1,77 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.presupuesto import (
+    PresupuestoCreate,
+    PresupuestoEstado,
+    PresupuestoResponse,
+    PresupuestoUpdate,
+)
+from app.services import presupuestos as svc
+
+router = APIRouter(prefix="/presupuestos", tags=["presupuestos"])
+
+
+@router.get("", response_model=list[PresupuestoResponse])
+async def list_presupuestos(
+    mes: int | None = Query(None, ge=1, le=12, description="Filtrar por mes (1-12)"),
+    year: int | None = Query(None, ge=2000, description="Filtrar por año"),
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.get_presupuestos(user_jwt=token, mes=mes, year=year)
+
+
+@router.post("", response_model=PresupuestoResponse, status_code=201)
+async def create_presupuesto(
+    data: PresupuestoCreate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.create_presupuesto(user_jwt=token, data=data)
+
+
+# IMPORTANTE: /estado debe ir ANTES de /{presupuesto_id} para evitar que el
+# path param capture la cadena literal "estado"
+@router.get("/estado", response_model=list[PresupuestoEstado])
+async def get_estado(
+    mes: int = Query(..., ge=1, le=12, description="Mes (1-12)"),
+    year: int = Query(..., ge=2000, description="Año"),
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.get_estado_presupuestos(user_jwt=token, mes=mes, year=year)
+
+
+@router.get("/{presupuesto_id}", response_model=PresupuestoResponse)
+async def get_presupuesto(
+    presupuesto_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.get_presupuesto_by_id(user_jwt=token, presupuesto_id=str(presupuesto_id))
+
+
+@router.put("/{presupuesto_id}", response_model=PresupuestoResponse)
+async def update_presupuesto(
+    presupuesto_id: UUID,
+    data: PresupuestoUpdate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.update_presupuesto(
+        user_jwt=token,
+        presupuesto_id=str(presupuesto_id),
+        data=data,
+    )
+
+
+@router.delete("/{presupuesto_id}", status_code=204)
+async def delete_presupuesto(
+    presupuesto_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    svc.delete_presupuesto(user_jwt=token, presupuesto_id=str(presupuesto_id))

--- a/backend/app/schemas/presupuesto.py
+++ b/backend/app/schemas/presupuesto.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PresupuestoCreate(BaseModel):
+    categoria_id: UUID
+    mes: int = Field(..., ge=1, le=12)
+    year: int = Field(..., ge=2000)
+    monto_limite: float = Field(..., gt=0)
+
+
+class PresupuestoUpdate(BaseModel):
+    monto_limite: float = Field(..., gt=0)
+
+
+class PresupuestoResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    categoria_id: UUID
+    mes: int
+    year: int
+    monto_limite: float
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PresupuestoEstado(BaseModel):
+    """Presupuesto con gasto real calculado del mes."""
+
+    id: UUID
+    categoria_id: UUID
+    categoria_nombre: str
+    mes: int
+    year: int
+    monto_limite: float
+    gasto_actual: float
+    porcentaje_usado: float
+    alerta: bool  # True si porcentaje_usado >= 80
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/presupuestos.py
+++ b/backend/app/services/presupuestos.py
@@ -1,0 +1,182 @@
+import calendar
+from uuid import UUID
+
+from fastapi import HTTPException
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.schemas.presupuesto import PresupuestoCreate, PresupuestoUpdate
+from app.services.base import _handle_api_error
+
+
+def get_presupuestos(
+    user_jwt: str,
+    mes: int | None = None,
+    year: int | None = None,
+) -> list[dict]:
+    client = get_user_client(user_jwt)
+    try:
+        query = (
+            client.table("presupuestos")
+            .select("*, categorias(nombre)")
+            .order("created_at", desc=True)
+        )
+        if mes is not None:
+            query = query.eq("mes", mes)
+        if year is not None:
+            query = query.eq("year", year)
+
+        response = query.execute()
+        return response.data or []
+    except APIError as e:
+        _handle_api_error(e)
+    return []
+
+
+def get_presupuesto_by_id(user_jwt: str, presupuesto_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("presupuestos")
+            .select("*, categorias(nombre)")
+            .eq("id", presupuesto_id)
+            .maybe_single()
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Presupuesto no encontrado.")
+        return response.data
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def create_presupuesto(user_jwt: str, data: PresupuestoCreate) -> dict:
+    client = get_user_client(user_jwt)
+    payload = {
+        "categoria_id": str(data.categoria_id),
+        "mes": data.mes,
+        "year": data.year,
+        "monto_limite": data.monto_limite,
+    }
+    try:
+        response = client.table("presupuestos").insert(payload).execute()
+        return response.data[0]
+    except IndexError:
+        raise HTTPException(
+            status_code=500, detail="Presupuesto no encontrado tras insercion."
+        )
+    except APIError as e:
+        # 23505 = unique_violation — detectado en _handle_api_error pero lo
+        # gestionamos aqui para dar un mensaje mas descriptivo
+        code = e.code or ""
+        if code == "23505" or "unique" in str(e.message).lower():
+            raise HTTPException(
+                status_code=409,
+                detail="Ya existe un presupuesto para esa categoria en ese mes/año.",
+            )
+        _handle_api_error(e)
+    return {}
+
+
+def update_presupuesto(
+    user_jwt: str, presupuesto_id: str, data: PresupuestoUpdate
+) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("presupuestos")
+            .update({"monto_limite": data.monto_limite})
+            .eq("id", presupuesto_id)
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Presupuesto no encontrado.")
+        return response.data[0]
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def delete_presupuesto(user_jwt: str, presupuesto_id: str) -> None:
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("presupuestos")
+            .delete()
+            .eq("id", presupuesto_id)
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Presupuesto no encontrado.")
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+
+
+def get_estado_presupuestos(user_jwt: str, mes: int, year: int) -> list[dict]:
+    """Retorna presupuestos del mes con gasto_actual calculado desde egresos."""
+    client = get_user_client(user_jwt)
+    try:
+        presupuestos_response = (
+            client.table("presupuestos")
+            .select("*, categorias(nombre)")
+            .eq("mes", mes)
+            .eq("year", year)
+            .execute()
+        )
+        presupuestos = presupuestos_response.data or []
+
+        last_day = calendar.monthrange(year, mes)[1]
+        fecha_inicio = f"{year}-{mes:02d}-01"
+        fecha_fin = f"{year}-{mes:02d}-{last_day:02d}"
+
+        resultado = []
+        for p in presupuestos:
+            egresos_response = (
+                client.table("egresos")
+                .select("monto")
+                .eq("categoria_id", p["categoria_id"])
+                .gte("fecha", fecha_inicio)
+                .lte("fecha", fecha_fin)
+                .execute()
+            )
+            gasto_actual = sum(
+                float(e["monto"]) for e in (egresos_response.data or [])
+            )
+            monto_limite = float(p["monto_limite"])
+            porcentaje = (
+                round(gasto_actual / monto_limite * 100, 2) if monto_limite > 0 else 0.0
+            )
+            categorias_data = p.get("categorias")
+            categoria_nombre = (
+                categorias_data.get("nombre", "")
+                if isinstance(categorias_data, dict)
+                else ""
+            )
+
+            resultado.append(
+                {
+                    "id": p["id"],
+                    "categoria_id": p["categoria_id"],
+                    "categoria_nombre": categoria_nombre,
+                    "mes": p["mes"],
+                    "year": p["year"],
+                    "monto_limite": monto_limite,
+                    "gasto_actual": round(gasto_actual, 2),
+                    "porcentaje_usado": porcentaje,
+                    "alerta": porcentaje >= 80,
+                }
+            )
+
+        return resultado
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return []

--- a/backend/tests/test_presupuestos.py
+++ b/backend/tests/test_presupuestos.py
@@ -1,0 +1,548 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from postgrest import APIError
+
+
+# ---------------------------------------------------------------------------
+# Auth guard tests — no token -> 403
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_presupuestos_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/presupuestos")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_presupuesto_requires_auth(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/v1/presupuestos",
+        json={
+            "categoria_id": "00000000-0000-0000-0000-000000000010",
+            "mes": 3,
+            "year": 2026,
+            "monto_limite": 5000.0,
+        },
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_estado_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/presupuestos/estado?mes=3&year=2026")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_presupuesto_by_id_requires_auth(client: AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/presupuestos/00000000-0000-0000-0000-000000000001"
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_presupuesto_requires_auth(client: AsyncClient) -> None:
+    response = await client.put(
+        "/api/v1/presupuestos/00000000-0000-0000-0000-000000000001",
+        json={"monto_limite": 8000.0},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_presupuesto_requires_auth(client: AsyncClient) -> None:
+    response = await client.delete(
+        "/api/v1/presupuestos/00000000-0000-0000-0000-000000000001"
+    )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Service unit tests — mock supabase client
+# ---------------------------------------------------------------------------
+
+
+def _make_presupuesto_row(
+    id_: str = "aaaa-0001",
+    user_id: str = "u1",
+    categoria_id: str = "cat-0001",
+    mes: int = 3,
+    year: int = 2026,
+    monto_limite: float = 5000.0,
+) -> dict:
+    return {
+        "id": id_,
+        "user_id": user_id,
+        "categoria_id": categoria_id,
+        "mes": mes,
+        "year": year,
+        "monto_limite": monto_limite,
+        "created_at": "2026-03-09T00:00:00+00:00",
+        "updated_at": "2026-03-09T00:00:00+00:00",
+        "categorias": {"nombre": "Alimentacion"},
+    }
+
+
+# --- create_presupuesto ---
+
+
+def test_create_presupuesto_success():
+    """create_presupuesto inserts correctly and returns the created row."""
+    from app.schemas.presupuesto import PresupuestoCreate
+    from app.services.presupuestos import create_presupuesto
+
+    inserted_row = _make_presupuesto_row()
+    mock_response = MagicMock()
+    mock_response.data = [inserted_row]
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.return_value = (
+        mock_response
+    )
+
+    data = PresupuestoCreate(
+        categoria_id="00000000-0000-0000-0000-000000000010",
+        mes=3,
+        year=2026,
+        monto_limite=5000.0,
+    )
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = create_presupuesto("fake-jwt", data)
+
+    assert result["id"] == "aaaa-0001"
+    insert_payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert insert_payload["mes"] == 3
+    assert insert_payload["year"] == 2026
+    assert insert_payload["monto_limite"] == 5000.0
+
+
+def test_create_presupuesto_duplicate_raises_409():
+    """create_presupuesto raises 409 on unique constraint violation."""
+    from app.schemas.presupuesto import PresupuestoCreate
+    from app.services.presupuestos import create_presupuesto
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.side_effect = APIError(
+        {"code": "23505", "message": "duplicate key value violates unique constraint"}
+    )
+
+    data = PresupuestoCreate(
+        categoria_id="00000000-0000-0000-0000-000000000010",
+        mes=3,
+        year=2026,
+        monto_limite=5000.0,
+    )
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            create_presupuesto("fake-jwt", data)
+
+    assert exc_info.value.status_code == 409
+    assert "categoria" in exc_info.value.detail.lower()
+
+
+def test_create_presupuesto_invalid_monto_limite():
+    """PresupuestoCreate raises ValidationError when monto_limite <= 0."""
+    from pydantic import ValidationError
+
+    from app.schemas.presupuesto import PresupuestoCreate
+
+    with pytest.raises(ValidationError):
+        PresupuestoCreate(
+            categoria_id="00000000-0000-0000-0000-000000000010",
+            mes=3,
+            year=2026,
+            monto_limite=0.0,
+        )
+
+
+def test_create_presupuesto_invalid_mes():
+    """PresupuestoCreate raises ValidationError when mes is out of range."""
+    from pydantic import ValidationError
+
+    from app.schemas.presupuesto import PresupuestoCreate
+
+    with pytest.raises(ValidationError):
+        PresupuestoCreate(
+            categoria_id="00000000-0000-0000-0000-000000000010",
+            mes=13,
+            year=2026,
+            monto_limite=1000.0,
+        )
+
+
+# --- get_presupuestos ---
+
+
+def test_get_presupuestos_returns_list():
+    """get_presupuestos returns a list of budgets for the user."""
+    from app.services.presupuestos import get_presupuestos
+
+    rows = [_make_presupuesto_row()]
+    mock_response = MagicMock()
+    mock_response.data = rows
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.order.return_value.execute.return_value
+    ) = mock_response
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = get_presupuestos("fake-jwt")
+
+    assert len(result) == 1
+    assert result[0]["id"] == "aaaa-0001"
+
+
+def test_get_presupuestos_with_mes_year_filter():
+    """get_presupuestos applies mes and year filters when provided."""
+    from app.services.presupuestos import get_presupuestos
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.order.return_value
+        .eq.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = get_presupuestos("fake-jwt", mes=3, year=2026)
+
+    assert result == []
+
+
+# --- get_presupuesto_by_id ---
+
+
+def test_get_presupuesto_by_id_not_found_raises_404():
+    """get_presupuesto_by_id raises 404 when record does not exist."""
+    from app.services.presupuestos import get_presupuesto_by_id
+
+    mock_response = MagicMock()
+    mock_response.data = None
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value
+        .maybe_single.return_value.execute.return_value
+    ) = mock_response
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            get_presupuesto_by_id("fake-jwt", "nonexistent-id")
+
+    assert exc_info.value.status_code == 404
+
+
+def test_get_presupuesto_by_id_success():
+    """get_presupuesto_by_id returns the presupuesto when found."""
+    from app.services.presupuestos import get_presupuesto_by_id
+
+    row = _make_presupuesto_row()
+    mock_response = MagicMock()
+    mock_response.data = row
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value
+        .maybe_single.return_value.execute.return_value
+    ) = mock_response
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = get_presupuesto_by_id("fake-jwt", "aaaa-0001")
+
+    assert result["id"] == "aaaa-0001"
+    assert result["monto_limite"] == 5000.0
+
+
+# --- update_presupuesto ---
+
+
+def test_update_presupuesto_success():
+    """update_presupuesto updates monto_limite and returns the updated row."""
+    from app.schemas.presupuesto import PresupuestoUpdate
+    from app.services.presupuestos import update_presupuesto
+
+    updated_row = _make_presupuesto_row(monto_limite=8000.0)
+    mock_response = MagicMock()
+    mock_response.data = [updated_row]
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    data = PresupuestoUpdate(monto_limite=8000.0)
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = update_presupuesto("fake-jwt", "aaaa-0001", data)
+
+    assert result["monto_limite"] == 8000.0
+
+
+def test_update_presupuesto_not_found_raises_404():
+    """update_presupuesto raises 404 when the record is not found."""
+    from app.schemas.presupuesto import PresupuestoUpdate
+    from app.services.presupuestos import update_presupuesto
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.update.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    data = PresupuestoUpdate(monto_limite=8000.0)
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            update_presupuesto("fake-jwt", "nonexistent-id", data)
+
+    assert exc_info.value.status_code == 404
+
+
+# --- delete_presupuesto ---
+
+
+def test_delete_presupuesto_success():
+    """delete_presupuesto deletes without raising when the record exists."""
+    from app.services.presupuestos import delete_presupuesto
+
+    deleted_row = _make_presupuesto_row()
+    mock_response = MagicMock()
+    mock_response.data = [deleted_row]
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.delete.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        # Should not raise
+        delete_presupuesto("fake-jwt", "aaaa-0001")
+
+
+def test_delete_presupuesto_not_found_raises_404():
+    """delete_presupuesto raises 404 when the record does not exist."""
+    from app.services.presupuestos import delete_presupuesto
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.delete.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            delete_presupuesto("fake-jwt", "nonexistent-id")
+
+    assert exc_info.value.status_code == 404
+
+
+# --- get_estado_presupuestos ---
+
+
+def test_get_estado_estructura():
+    """get_estado_presupuestos returns PresupuestoEstado structure."""
+    from app.services.presupuestos import get_estado_presupuestos
+
+    presupuesto_row = {
+        "id": "aaaa-0001",
+        "user_id": "u1",
+        "categoria_id": "cat-0001",
+        "mes": 3,
+        "year": 2026,
+        "monto_limite": 5000.0,
+        "created_at": "2026-03-09T00:00:00+00:00",
+        "updated_at": "2026-03-09T00:00:00+00:00",
+        "categorias": {"nombre": "Alimentacion"},
+    }
+    egreso_rows = [{"monto": "1500.00"}, {"monto": "500.00"}]
+
+    mock_presupuestos_response = MagicMock()
+    mock_presupuestos_response.data = [presupuesto_row]
+
+    mock_egresos_response = MagicMock()
+    mock_egresos_response.data = egreso_rows
+
+    mock_client = MagicMock()
+
+    def table_side_effect(table_name: str):
+        m = MagicMock()
+        if table_name == "presupuestos":
+            (
+                m.select.return_value.eq.return_value.eq.return_value.execute.return_value
+            ) = mock_presupuestos_response
+        else:
+            # egresos
+            (
+                m.select.return_value.eq.return_value.gte.return_value.lte.return_value.execute.return_value
+            ) = mock_egresos_response
+        return m
+
+    mock_client.table.side_effect = table_side_effect
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = get_estado_presupuestos("fake-jwt", mes=3, year=2026)
+
+    assert len(result) == 1
+    estado = result[0]
+    assert "monto_limite" in estado
+    assert "gasto_actual" in estado
+    assert "porcentaje_usado" in estado
+    assert "alerta" in estado
+    assert "categoria_nombre" in estado
+    assert estado["gasto_actual"] == 2000.0
+    assert estado["monto_limite"] == 5000.0
+    assert estado["porcentaje_usado"] == 40.0
+    assert estado["alerta"] is False
+    assert estado["categoria_nombre"] == "Alimentacion"
+
+
+def test_get_estado_alerta_true_when_porcentaje_gte_80():
+    """get_estado_presupuestos sets alerta=True when porcentaje_usado >= 80."""
+    from app.services.presupuestos import get_estado_presupuestos
+
+    presupuesto_row = {
+        "id": "aaaa-0002",
+        "user_id": "u1",
+        "categoria_id": "cat-0002",
+        "mes": 3,
+        "year": 2026,
+        "monto_limite": 1000.0,
+        "created_at": "2026-03-09T00:00:00+00:00",
+        "updated_at": "2026-03-09T00:00:00+00:00",
+        "categorias": {"nombre": "Entretenimiento"},
+    }
+    # gasto = 900 sobre limite 1000 => 90% => alerta True
+    egreso_rows = [{"monto": "500.00"}, {"monto": "400.00"}]
+
+    mock_presupuestos_response = MagicMock()
+    mock_presupuestos_response.data = [presupuesto_row]
+
+    mock_egresos_response = MagicMock()
+    mock_egresos_response.data = egreso_rows
+
+    mock_client = MagicMock()
+
+    def table_side_effect(table_name: str):
+        m = MagicMock()
+        if table_name == "presupuestos":
+            (
+                m.select.return_value.eq.return_value.eq.return_value.execute.return_value
+            ) = mock_presupuestos_response
+        else:
+            (
+                m.select.return_value.eq.return_value.gte.return_value.lte.return_value.execute.return_value
+            ) = mock_egresos_response
+        return m
+
+    mock_client.table.side_effect = table_side_effect
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = get_estado_presupuestos("fake-jwt", mes=3, year=2026)
+
+    assert len(result) == 1
+    estado = result[0]
+    assert estado["gasto_actual"] == 900.0
+    assert estado["porcentaje_usado"] == 90.0
+    assert estado["alerta"] is True
+
+
+def test_get_estado_sin_presupuestos_retorna_lista_vacia():
+    """get_estado_presupuestos returns [] when no budgets exist for the month."""
+    from app.services.presupuestos import get_estado_presupuestos
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        result = get_estado_presupuestos("fake-jwt", mes=1, year=2026)
+
+    assert result == []
+
+
+def test_get_presupuestos_api_error_raises_500():
+    """get_presupuestos raises HTTP 500 on unexpected Supabase APIError."""
+    from app.services.presupuestos import get_presupuestos
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.order.return_value.execute.side_effect
+    ) = APIError({"code": "503", "message": "Service unavailable"})
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            get_presupuestos("fake-jwt")
+
+    assert exc_info.value.status_code == 500
+
+
+def test_create_presupuesto_api_error_raises_http():
+    """create_presupuesto propagates APIError as HTTPException."""
+    from app.schemas.presupuesto import PresupuestoCreate
+    from app.services.presupuestos import create_presupuesto
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.side_effect = APIError(
+        {"code": "400", "message": "Bad request"}
+    )
+
+    data = PresupuestoCreate(
+        categoria_id="00000000-0000-0000-0000-000000000010",
+        mes=3,
+        year=2026,
+        monto_limite=1000.0,
+    )
+
+    with patch(
+        "app.services.presupuestos.get_user_client", return_value=mock_client
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            create_presupuesto("fake-jwt", data)
+
+    assert exc_info.value.status_code == 400

--- a/supabase/migrations/20260309000003_presupuestos.sql
+++ b/supabase/migrations/20260309000003_presupuestos.sql
@@ -1,0 +1,42 @@
+-- Tabla presupuestos
+CREATE TABLE IF NOT EXISTS presupuestos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    categoria_id UUID NOT NULL REFERENCES categorias(id) ON DELETE CASCADE,
+    mes INTEGER NOT NULL CHECK (mes BETWEEN 1 AND 12),
+    year INTEGER NOT NULL CHECK (year >= 2000),
+    monto_limite NUMERIC NOT NULL CHECK (monto_limite > 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT presupuestos_unique_user_cat_mes_year
+        UNIQUE (user_id, categoria_id, mes, year)
+);
+
+-- Trigger updated_at (update_updated_at_column ya existe en la DB)
+CREATE TRIGGER update_presupuestos_updated_at
+    BEFORE UPDATE ON presupuestos
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- RLS
+ALTER TABLE presupuestos ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own presupuestos"
+    ON presupuestos FOR SELECT
+    USING (user_id = auth.uid());
+
+CREATE POLICY "Users can insert own presupuestos"
+    ON presupuestos FOR INSERT
+    WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can update own presupuestos"
+    ON presupuestos FOR UPDATE
+    USING (user_id = auth.uid());
+
+CREATE POLICY "Users can delete own presupuestos"
+    ON presupuestos FOR DELETE
+    USING (user_id = auth.uid());
+
+-- Indices
+CREATE INDEX idx_presupuestos_user_id ON presupuestos(user_id);
+CREATE INDEX idx_presupuestos_mes_year ON presupuestos(mes, year);
+CREATE INDEX idx_presupuestos_categoria_id ON presupuestos(categoria_id);


### PR DESCRIPTION
## Summary

- Migración SQL `20260309000003_presupuestos.sql`: tabla `presupuestos` con constraint UNIQUE por `(user_id, categoria_id, mes, year)`, RLS policies, trigger `updated_at` e índices
- Schemas Pydantic v2: `PresupuestoCreate`, `PresupuestoUpdate`, `PresupuestoResponse`, `PresupuestoEstado`
- Service layer (`app/services/presupuestos.py`): CRUD completo + `get_estado_presupuestos` que calcula `gasto_actual` iterando egresos por categoría/mes
- Routes (`app/api/v1/routes/presupuestos.py`): `GET /estado` registrado antes de `/{id}` para evitar captura del path param
- Router principal actualizado con `presupuestos_router`

## Endpoints

| Method | Path | Status |
|--------|------|--------|
| GET | `/api/v1/presupuestos` | 200 |
| POST | `/api/v1/presupuestos` | 201 |
| GET | `/api/v1/presupuestos/estado?mes=&year=` | 200 |
| GET | `/api/v1/presupuestos/{id}` | 200 |
| PUT | `/api/v1/presupuestos/{id}` | 200 |
| DELETE | `/api/v1/presupuestos/{id}` | 204 |

## Tests

- 23 tests, 23 passing (`docker exec finza-backend python -m pytest tests/test_presupuestos.py -v`)
- Suite completa: 163 passed, 0 failed

### Cobertura de casos
- Auth guard → 403 para todos los endpoints sin token
- `create` happy path → 201
- `create` duplicado (UNIQUE violation 23505) → 409
- `create` validación monto/mes inválido → ValidationError
- `list` → retorna lista
- `get_by_id` → 200 / 404
- `update` → 200 / 404
- `delete` → 204 / 404
- `get_estado` → estructura correcta con `gasto_actual`, `porcentaje_usado`, `alerta`
- `get_estado` alerta=True cuando porcentaje >= 80
- APIError inesperado → 500

Closes #48