### PR TITLE
feat(frontend): monthly budget page with progress bars and spending alerts — closes #49

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { IngresosPage } from '@/pages/IngresosPage'
 import { EgresosPage } from '@/pages/EgresosPage'
 import { PrestamosPage } from '@/pages/PrestamosPage'
 import { MetasPage } from '@/pages/MetasPage'
+import { PresupuestosPage } from '@/pages/PresupuestosPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -57,7 +58,7 @@ export function App(): JSX.Element {
               <Route path="/egresos" element={<EgresosPage />} />
               <Route path="/prestamos" element={<PrestamosPage />} />
               <Route path="/metas" element={<MetasPage />} />
-              <Route path="/presupuestos" element={<div className="p-4">Presupuestos - Issue futuro</div>} />
+              <Route path="/presupuestos" element={<PresupuestosPage />} />
               <Route path="/reportes" element={<div className="p-4">Reportes - Issue futuro</div>} />
               <Route path="/configuracion" element={<div className="p-4">Configuracion - Issue futuro</div>} />
             </Route>

--- a/frontend/src/features/presupuestos/__tests__/BudgetProgressBar.test.tsx
+++ b/frontend/src/features/presupuestos/__tests__/BudgetProgressBar.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { BudgetProgressBar } from '../components/BudgetProgressBar'
+
+describe('BudgetProgressBar', () => {
+  it('renders correctly with default props', () => {
+    render(<BudgetProgressBar porcentaje={50} />)
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('shows green color when porcentaje < 80', () => {
+    render(<BudgetProgressBar porcentaje={50} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.className).toContain('bg-prosperity-green')
+  })
+
+  it('shows yellow color when porcentaje is between 80 and 99', () => {
+    render(<BudgetProgressBar porcentaje={85} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.className).toContain('bg-golden-flow')
+  })
+
+  it('shows red color when porcentaje >= 100', () => {
+    render(<BudgetProgressBar porcentaje={100} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.className).toContain('bg-alert-red')
+  })
+
+  it('shows red color when porcentaje > 100', () => {
+    render(<BudgetProgressBar porcentaje={120} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.className).toContain('bg-alert-red')
+  })
+
+  it('sets aria-valuenow to rounded porcentaje', () => {
+    render(<BudgetProgressBar porcentaje={70.6} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '71')
+  })
+
+  it('caps width at 100% when porcentaje exceeds 100', () => {
+    render(<BudgetProgressBar porcentaje={150} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.style.width).toBe('100%')
+  })
+
+  it('sets aria-valuemin and aria-valuemax', () => {
+    render(<BudgetProgressBar porcentaje={50} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuemin', '0')
+    expect(bar).toHaveAttribute('aria-valuemax', '100')
+  })
+
+  it('accepts custom aria-label', () => {
+    render(
+      <BudgetProgressBar
+        porcentaje={50}
+        aria-label="50% del presupuesto usado"
+      />
+    )
+    expect(
+      screen.getByRole('progressbar', { name: '50% del presupuesto usado' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows yellow color at exactly 80%', () => {
+    render(<BudgetProgressBar porcentaje={80} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.className).toContain('bg-golden-flow')
+  })
+
+  it('shows green when porcentaje is 0', () => {
+    render(<BudgetProgressBar porcentaje={0} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.className).toContain('bg-prosperity-green')
+  })
+})

--- a/frontend/src/features/presupuestos/__tests__/PresupuestoCard.test.tsx
+++ b/frontend/src/features/presupuestos/__tests__/PresupuestoCard.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PresupuestoCard } from '../components/PresupuestoCard'
+import type { PresupuestoEstado } from '@/types/presupuesto'
+
+const mockEstadoNormal: PresupuestoEstado = {
+  id: 'pres-1',
+  categoria_id: 'cat-1',
+  categoria_nombre: 'Alimentacion',
+  mes: 3,
+  year: 2026,
+  monto_limite: 500,
+  gasto_actual: 350,
+  porcentaje_usado: 70,
+  alerta: false,
+}
+
+const mockEstadoAlerta: PresupuestoEstado = {
+  ...mockEstadoNormal,
+  id: 'pres-2',
+  categoria_nombre: 'Transporte',
+  gasto_actual: 480,
+  porcentaje_usado: 96,
+  alerta: true,
+}
+
+const mockEstadoExcedido: PresupuestoEstado = {
+  ...mockEstadoNormal,
+  id: 'pres-3',
+  categoria_nombre: 'Entretenimiento',
+  gasto_actual: 600,
+  porcentaje_usado: 120,
+  alerta: true,
+}
+
+describe('PresupuestoCard', () => {
+  it('renders correctly with default props', () => {
+    render(<PresupuestoCard estado={mockEstadoNormal} onClick={vi.fn()} />)
+    expect(screen.getByText('Alimentacion')).toBeInTheDocument()
+  })
+
+  it('shows progress bar with correct percentage', () => {
+    render(<PresupuestoCard estado={mockEstadoNormal} onClick={vi.fn()} />)
+    const progressBar = screen.getByRole('progressbar')
+    expect(progressBar).toHaveAttribute('aria-valuenow', '70')
+    expect(screen.getByText('70% usado')).toBeInTheDocument()
+  })
+
+  it('does not show alert badge when alerta is false', () => {
+    render(<PresupuestoCard estado={mockEstadoNormal} onClick={vi.fn()} />)
+    expect(screen.queryByText(/alerta/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/excedido/i)).not.toBeInTheDocument()
+  })
+
+  it('shows Alerta badge when alerta is true and not exceeded', () => {
+    render(<PresupuestoCard estado={mockEstadoAlerta} onClick={vi.fn()} />)
+    expect(screen.getByText(/alerta/i)).toBeInTheDocument()
+    expect(screen.queryByText(/excedido/i)).not.toBeInTheDocument()
+  })
+
+  it('shows Excedido badge when porcentaje_usado >= 100', () => {
+    render(<PresupuestoCard estado={mockEstadoExcedido} onClick={vi.fn()} />)
+    expect(screen.getByText(/excedido/i)).toBeInTheDocument()
+    expect(screen.queryByText(/alerta/i)).not.toBeInTheDocument()
+  })
+
+  it('calls onClick with estado when clicked', () => {
+    const handleClick = vi.fn()
+    render(<PresupuestoCard estado={mockEstadoNormal} onClick={handleClick} />)
+    screen
+      .getByRole('button', { name: /editar presupuesto de alimentacion/i })
+      .click()
+    expect(handleClick).toHaveBeenCalledWith(mockEstadoNormal)
+  })
+
+  it('caps visual width at 100% when porcentaje_usado exceeds 100', () => {
+    render(<PresupuestoCard estado={mockEstadoExcedido} onClick={vi.fn()} />)
+    const progressBar = screen.getByRole('progressbar')
+    // aria-valuenow reflects real usage; the visual width is capped via style
+    expect(progressBar).toHaveAttribute('aria-valuenow')
+    expect(Number(progressBar.style.width.replace('%', ''))).toBeLessThanOrEqual(100)
+  })
+
+  it('shows gastado and limite labels', () => {
+    render(<PresupuestoCard estado={mockEstadoNormal} onClick={vi.fn()} />)
+    expect(screen.getByText('Gastado')).toBeInTheDocument()
+    expect(screen.getByText('Limite')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/presupuestos/__tests__/PresupuestosPage.test.tsx
+++ b/frontend/src/features/presupuestos/__tests__/PresupuestosPage.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { PresupuestosPage } from '@/pages/PresupuestosPage'
+import type { PresupuestoEstado } from '@/types/presupuesto'
+import type { CategoriaResponse } from '@/types/transacciones'
+
+// Mock hooks
+vi.mock('@/hooks/usePresupuestos', () => ({
+  usePresupuestosEstado: vi.fn(),
+  useCreatePresupuesto: vi.fn(),
+  useUpdatePresupuesto: vi.fn(),
+  useDeletePresupuesto: vi.fn(),
+}))
+
+vi.mock('@/hooks/useCategorias', () => ({
+  useCategorias: vi.fn(),
+}))
+
+import {
+  usePresupuestosEstado,
+  useCreatePresupuesto,
+  useUpdatePresupuesto,
+  useDeletePresupuesto,
+} from '@/hooks/usePresupuestos'
+import { useCategorias } from '@/hooks/useCategorias'
+
+const mockEstados: PresupuestoEstado[] = [
+  {
+    id: 'pres-1',
+    categoria_id: 'cat-1',
+    categoria_nombre: 'Alimentacion',
+    mes: 3,
+    year: 2026,
+    monto_limite: 500,
+    gasto_actual: 350,
+    porcentaje_usado: 70,
+    alerta: false,
+  },
+  {
+    id: 'pres-2',
+    categoria_id: 'cat-2',
+    categoria_nombre: 'Transporte',
+    mes: 3,
+    year: 2026,
+    monto_limite: 500,
+    gasto_actual: 480,
+    porcentaje_usado: 96,
+    alerta: true,
+  },
+]
+
+const mockCategorias: CategoriaResponse[] = [
+  {
+    id: 'cat-1',
+    nombre: 'Alimentacion',
+    tipo: 'egreso',
+    icono: null,
+    color: null,
+    es_sistema: true,
+  },
+  {
+    id: 'cat-2',
+    nombre: 'Transporte',
+    tipo: 'egreso',
+    icono: null,
+    color: null,
+    es_sistema: true,
+  },
+  {
+    id: 'cat-3',
+    nombre: 'Servicios',
+    tipo: 'egreso',
+    icono: null,
+    color: null,
+    es_sistema: true,
+  },
+  {
+    id: 'cat-4',
+    nombre: 'Salario',
+    tipo: 'ingreso',
+    icono: null,
+    color: null,
+    es_sistema: true,
+  },
+]
+
+function setupMocks({
+  estadoData = mockEstados,
+  categoriasData = mockCategorias,
+  isLoading = false,
+  isError = false,
+}: {
+  estadoData?: PresupuestoEstado[]
+  categoriasData?: CategoriaResponse[]
+  isLoading?: boolean
+  isError?: boolean
+} = {}) {
+  vi.mocked(usePresupuestosEstado).mockReturnValue({
+    data: estadoData,
+    isLoading,
+    isError,
+    isPending: false,
+    isSuccess: !isLoading && !isError,
+    error: null,
+  } as ReturnType<typeof usePresupuestosEstado>)
+
+  vi.mocked(useCategorias).mockReturnValue({
+    data: categoriasData,
+    isLoading: false,
+    isError: false,
+    isPending: false,
+    isSuccess: true,
+    error: null,
+  } as ReturnType<typeof useCategorias>)
+
+  vi.mocked(useCreatePresupuesto).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCreatePresupuesto>)
+
+  vi.mocked(useUpdatePresupuesto).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdatePresupuesto>)
+
+  vi.mocked(useDeletePresupuesto).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDeletePresupuesto>)
+}
+
+describe('PresupuestosPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders page title', () => {
+    render(<PresupuestosPage />)
+    expect(screen.getByText('Presupuestos')).toBeInTheDocument()
+  })
+
+  it('renders Nuevo button', () => {
+    render(<PresupuestosPage />)
+    expect(screen.getByRole('button', { name: /nuevo/i })).toBeInTheDocument()
+  })
+
+  it('renders mes and year selectors', () => {
+    render(<PresupuestosPage />)
+    expect(screen.getByLabelText('Mes')).toBeInTheDocument()
+    expect(screen.getByLabelText('Año')).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton state', () => {
+    setupMocks({ isLoading: true, estadoData: [] })
+    render(<PresupuestosPage />)
+    expect(screen.queryByText('Alimentacion')).not.toBeInTheDocument()
+  })
+
+  it('shows error state gracefully', () => {
+    setupMocks({ isError: true, estadoData: [] })
+    render(<PresupuestosPage />)
+    expect(
+      screen.getByText(/el servidor no esta disponible/i)
+    ).toBeInTheDocument()
+  })
+
+  it('shows empty state when no presupuestos', () => {
+    setupMocks({ estadoData: [] })
+    render(<PresupuestosPage />)
+    expect(
+      screen.getByText(/no hay presupuestos asignados para este mes/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders presupuesto cards when data is available', () => {
+    render(<PresupuestosPage />)
+    expect(screen.getByText('Alimentacion')).toBeInTheDocument()
+    expect(screen.getByText('Transporte')).toBeInTheDocument()
+  })
+
+  it('shows "Sin presupuesto" section for categories without budget', () => {
+    render(<PresupuestosPage />)
+    expect(screen.getByText(/sin presupuesto/i)).toBeInTheDocument()
+    expect(screen.getByText('Servicios')).toBeInTheDocument()
+  })
+
+  it('does not show ingreso categories in "Sin presupuesto" section', () => {
+    render(<PresupuestosPage />)
+    expect(screen.queryByText('Salario')).not.toBeInTheDocument()
+  })
+
+  it('opens create modal when Nuevo button is clicked', () => {
+    render(<PresupuestosPage />)
+    fireEvent.click(screen.getByRole('button', { name: /nuevo/i }))
+    expect(screen.getByRole('dialog', { name: /nuevo presupuesto/i })).toBeInTheDocument()
+  })
+
+  it('opens create modal pre-filled when Asignar limite is clicked', () => {
+    render(<PresupuestosPage />)
+    const asignarBtns = screen.getAllByRole('button', { name: /asignar limite/i })
+    fireEvent.click(asignarBtns[0])
+    expect(screen.getByRole('dialog', { name: /nuevo presupuesto/i })).toBeInTheDocument()
+  })
+
+  it('opens edit modal when a PresupuestoCard is clicked', () => {
+    render(<PresupuestosPage />)
+    fireEvent.click(
+      screen.getByRole('button', { name: /editar presupuesto de alimentacion/i })
+    )
+    expect(screen.getByRole('dialog', { name: /editar presupuesto/i })).toBeInTheDocument()
+  })
+
+  it('changes mes when selector changes', () => {
+    render(<PresupuestosPage />)
+    const mesSelect = screen.getByLabelText('Mes')
+    fireEvent.change(mesSelect, { target: { value: '6' } })
+    expect((mesSelect as HTMLSelectElement).value).toBe('6')
+  })
+})

--- a/frontend/src/features/presupuestos/components/BudgetProgressBar.tsx
+++ b/frontend/src/features/presupuestos/components/BudgetProgressBar.tsx
@@ -1,0 +1,31 @@
+interface BudgetProgressBarProps {
+  porcentaje: number
+  'aria-label'?: string
+}
+
+export function BudgetProgressBar({
+  porcentaje,
+  'aria-label': ariaLabel,
+}: BudgetProgressBarProps): JSX.Element {
+  const pct = Math.min(100, Math.max(0, porcentaje))
+  const colorClass =
+    porcentaje >= 100
+      ? 'bg-alert-red'
+      : porcentaje >= 80
+        ? 'bg-golden-flow'
+        : 'bg-prosperity-green'
+
+  return (
+    <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden">
+      <div
+        className={`${colorClass} h-2.5 rounded-full transition-all duration-300`}
+        style={{ width: `${pct}%` }}
+        role="progressbar"
+        aria-valuenow={Math.round(porcentaje)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={ariaLabel ?? `${Math.round(porcentaje)}% usado`}
+      />
+    </div>
+  )
+}

--- a/frontend/src/features/presupuestos/components/PresupuestoCard.tsx
+++ b/frontend/src/features/presupuestos/components/PresupuestoCard.tsx
@@ -1,0 +1,77 @@
+import { AlertTriangle } from 'lucide-react'
+import { BudgetProgressBar } from './BudgetProgressBar'
+import { formatMoney } from '@/lib/utils'
+import type { PresupuestoEstado } from '@/types/presupuesto'
+
+interface PresupuestoCardProps {
+  estado: PresupuestoEstado
+  onClick: (estado: PresupuestoEstado) => void
+}
+
+export function PresupuestoCard({
+  estado,
+  onClick,
+}: PresupuestoCardProps): JSX.Element {
+  const excedido = estado.porcentaje_usado >= 100
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(estado)}
+      className="finza-card text-left w-full transition-all hover:shadow-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-finza-blue"
+      aria-label={`Editar presupuesto de ${estado.categoria_nombre}`}
+    >
+      {/* Header: nombre + badges de alerta */}
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <p className="text-sm font-semibold text-gray-900 truncate">
+          {estado.categoria_nombre}
+        </p>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {excedido ? (
+            <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-red-100 text-alert-red whitespace-nowrap">
+              Excedido
+            </span>
+          ) : estado.alerta ? (
+            <span className="flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-yellow-100 text-golden-flow whitespace-nowrap">
+              <AlertTriangle size={11} aria-hidden="true" />
+              Alerta
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Montos */}
+      <div className="flex items-end justify-between mb-2">
+        <div>
+          <p className="text-xs text-gray-400">Gastado</p>
+          <p
+            className={`text-lg font-bold money ${
+              excedido
+                ? 'text-alert-red'
+                : estado.alerta
+                  ? 'text-golden-flow'
+                  : 'text-gray-900'
+            }`}
+          >
+            {formatMoney(estado.gasto_actual)}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-gray-400">Limite</p>
+          <p className="text-sm font-semibold text-gray-600">
+            {formatMoney(estado.monto_limite)}
+          </p>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <BudgetProgressBar
+        porcentaje={estado.porcentaje_usado}
+        aria-label={`${Math.round(estado.porcentaje_usado)}% del presupuesto de ${estado.categoria_nombre} usado`}
+      />
+      <p className="text-xs text-gray-400 mt-1">
+        {Math.round(estado.porcentaje_usado)}% usado
+      </p>
+    </button>
+  )
+}

--- a/frontend/src/features/presupuestos/components/PresupuestoForm.tsx
+++ b/frontend/src/features/presupuestos/components/PresupuestoForm.tsx
@@ -1,0 +1,143 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useCategorias } from '@/hooks/useCategorias'
+
+const presupuestoSchema = z.object({
+  categoria_id: z.string().min(1, 'Selecciona una categoria'),
+  monto_limite: z
+    .number({ invalid_type_error: 'Ingresa un monto valido' })
+    .positive('El monto limite debe ser mayor a 0'),
+})
+
+export type PresupuestoFormData = z.infer<typeof presupuestoSchema>
+
+interface PresupuestoFormProps {
+  mes: number
+  year: number
+  categoriaIdInicial?: string
+  montoLimiteInicial?: number
+  isEditing?: boolean
+  errorMessage?: string | null
+  onSubmit: (data: PresupuestoFormData) => Promise<void>
+  onCancel: () => void
+  isLoading?: boolean
+}
+
+const MESES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+]
+
+export function PresupuestoForm({
+  mes,
+  year,
+  categoriaIdInicial,
+  montoLimiteInicial,
+  isEditing = false,
+  errorMessage,
+  onSubmit,
+  onCancel,
+  isLoading,
+}: PresupuestoFormProps): JSX.Element {
+  const { data: categorias = [], isLoading: loadingCategorias } =
+    useCategorias()
+
+  // Solo categorias de egreso o ambos
+  const categoriasEgreso = categorias.filter(
+    (c) => c.tipo === 'egreso' || c.tipo === 'ambos'
+  )
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<PresupuestoFormData>({
+    resolver: zodResolver(presupuestoSchema),
+    defaultValues: {
+      categoria_id: categoriaIdInicial ?? '',
+      monto_limite: montoLimiteInicial ?? undefined,
+    },
+  })
+
+  const handleFormSubmit = handleSubmit((data) => onSubmit(data))
+
+  return (
+    <form onSubmit={handleFormSubmit} className="flex flex-col gap-4">
+      {/* Periodo — read only */}
+      <div className="flex gap-2 p-3 bg-gray-50 rounded-lg">
+        <div className="flex-1">
+          <p className="text-xs text-gray-500 mb-0.5">Mes</p>
+          <p className="text-sm font-medium text-gray-800">
+            {MESES[mes - 1]}
+          </p>
+        </div>
+        <div className="flex-1">
+          <p className="text-xs text-gray-500 mb-0.5">Año</p>
+          <p className="text-sm font-medium text-gray-800">{year}</p>
+        </div>
+      </div>
+
+      {/* Categoria */}
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor="presupuesto-categoria"
+          className="text-sm font-medium text-gray-700"
+        >
+          Categoria
+        </label>
+        <select
+          id="presupuesto-categoria"
+          disabled={isEditing || loadingCategorias}
+          className="finza-input w-full disabled:opacity-60 disabled:cursor-not-allowed"
+          {...register('categoria_id')}
+          aria-describedby={
+            errors.categoria_id ? 'categoria-error' : undefined
+          }
+        >
+          <option value="">Selecciona una categoria...</option>
+          {categoriasEgreso.map((cat) => (
+            <option key={cat.id} value={cat.id}>
+              {cat.icono ? `${cat.icono} ` : ''}
+              {cat.nombre}
+            </option>
+          ))}
+        </select>
+        {errors.categoria_id && (
+          <p id="categoria-error" className="text-xs text-alert-red">
+            {errors.categoria_id.message}
+          </p>
+        )}
+      </div>
+
+      {/* Monto limite */}
+      <Input
+        label="Monto limite"
+        type="number"
+        step="0.01"
+        min="0.01"
+        placeholder="0.00"
+        error={errors.monto_limite?.message}
+        {...register('monto_limite', { valueAsNumber: true })}
+      />
+
+      {/* Error externo (ej: 409) */}
+      {errorMessage && (
+        <p className="text-xs text-alert-red bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {errorMessage}
+        </p>
+      )}
+
+      <div className="flex gap-3 justify-end mt-2">
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Cancelar
+        </Button>
+        <Button type="submit" variant="default" isLoading={isLoading}>
+          {isEditing ? 'Guardar cambios' : 'Crear presupuesto'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/features/presupuestos/components/PresupuestoModal.tsx
+++ b/frontend/src/features/presupuestos/components/PresupuestoModal.tsx
@@ -1,0 +1,88 @@
+import { Trash2, X } from 'lucide-react'
+import { PresupuestoForm } from './PresupuestoForm'
+import type { PresupuestoFormData } from './PresupuestoForm'
+
+interface PresupuestoModalProps {
+  isOpen: boolean
+  mes: number
+  year: number
+  categoriaIdInicial?: string
+  montoLimiteInicial?: number
+  isEditing?: boolean
+  errorMessage?: string | null
+  onClose: () => void
+  onSubmit: (data: PresupuestoFormData) => Promise<void>
+  onDelete?: () => void
+  isLoading?: boolean
+}
+
+export function PresupuestoModal({
+  isOpen,
+  mes,
+  year,
+  categoriaIdInicial,
+  montoLimiteInicial,
+  isEditing = false,
+  errorMessage,
+  onClose,
+  onSubmit,
+  onDelete,
+  isLoading,
+}: PresupuestoModalProps): JSX.Element | null {
+  if (!isOpen) return null
+
+  const title = isEditing ? 'Editar presupuesto' : 'Nuevo presupuesto'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative bg-white rounded-card shadow-card-hover w-full max-w-md max-h-[90vh] overflow-y-auto p-6">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-bold text-gray-900">{title}</h2>
+          <div className="flex items-center gap-2">
+            {isEditing && onDelete && (
+              <button
+                type="button"
+                onClick={onDelete}
+                className="text-gray-400 hover:text-alert-red transition-colors"
+                aria-label="Eliminar presupuesto"
+              >
+                <Trash2 size={18} />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label="Cerrar"
+            >
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        <PresupuestoForm
+          mes={mes}
+          year={year}
+          categoriaIdInicial={categoriaIdInicial}
+          montoLimiteInicial={montoLimiteInicial}
+          isEditing={isEditing}
+          errorMessage={errorMessage}
+          onSubmit={onSubmit}
+          onCancel={onClose}
+          isLoading={isLoading}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/usePresupuestos.ts
+++ b/frontend/src/hooks/usePresupuestos.ts
@@ -1,0 +1,74 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  fetchPresupuestosEstado,
+  createPresupuesto,
+  updatePresupuesto,
+  deletePresupuesto,
+} from '@/lib/api/presupuestos'
+import type {
+  PresupuestoCreate,
+  PresupuestoUpdate,
+  PresupuestoEstado,
+  Presupuesto,
+} from '@/types/presupuesto'
+
+// ─── Query key factory ──────────────────────────────────────────────────────
+
+export const presupuestosKeys = {
+  all: ['presupuestos'] as const,
+  estado: (mes: number, year: number) =>
+    ['presupuestos', mes, year] as const,
+}
+
+// ─── Queries ────────────────────────────────────────────────────────────────
+
+export function usePresupuestosEstado(mes: number, year: number) {
+  return useQuery({
+    queryKey: presupuestosKeys.estado(mes, year),
+    queryFn: (): Promise<PresupuestoEstado[]> =>
+      fetchPresupuestosEstado(mes, year),
+  })
+}
+
+// ─── Mutations ──────────────────────────────────────────────────────────────
+
+export function useCreatePresupuesto(mes: number, year: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: PresupuestoCreate): Promise<Presupuesto> =>
+      createPresupuesto(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: presupuestosKeys.estado(mes, year),
+      })
+    },
+  })
+}
+
+export function useUpdatePresupuesto(mes: number, year: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      id,
+      ...payload
+    }: { id: string } & PresupuestoUpdate): Promise<Presupuesto> =>
+      updatePresupuesto(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: presupuestosKeys.estado(mes, year),
+      })
+    },
+  })
+}
+
+export function useDeletePresupuesto(mes: number, year: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string): Promise<void> => deletePresupuesto(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: presupuestosKeys.estado(mes, year),
+      })
+    },
+  })
+}

--- a/frontend/src/lib/api/presupuestos.ts
+++ b/frontend/src/lib/api/presupuestos.ts
@@ -1,0 +1,54 @@
+import { apiClient } from '@/lib/api'
+import type {
+  Presupuesto,
+  PresupuestoCreate,
+  PresupuestoUpdate,
+  PresupuestoEstado,
+} from '@/types/presupuesto'
+
+export async function fetchPresupuestosEstado(
+  mes: number,
+  year: number
+): Promise<PresupuestoEstado[]> {
+  const { data } = await apiClient.get<PresupuestoEstado[]>(
+    `/presupuestos/estado?mes=${mes}&year=${year}`
+  )
+  return data
+}
+
+export async function fetchPresupuestos(
+  mes: number,
+  year: number
+): Promise<Presupuesto[]> {
+  const { data } = await apiClient.get<Presupuesto[]>(
+    `/presupuestos?mes=${mes}&year=${year}`
+  )
+  return data
+}
+
+export async function fetchPresupuestoById(id: string): Promise<Presupuesto> {
+  const { data } = await apiClient.get<Presupuesto>(`/presupuestos/${id}`)
+  return data
+}
+
+export async function createPresupuesto(
+  payload: PresupuestoCreate
+): Promise<Presupuesto> {
+  const { data } = await apiClient.post<Presupuesto>('/presupuestos', payload)
+  return data
+}
+
+export async function updatePresupuesto(
+  id: string,
+  payload: PresupuestoUpdate
+): Promise<Presupuesto> {
+  const { data } = await apiClient.put<Presupuesto>(
+    `/presupuestos/${id}`,
+    payload
+  )
+  return data
+}
+
+export async function deletePresupuesto(id: string): Promise<void> {
+  await apiClient.delete(`/presupuestos/${id}`)
+}

--- a/frontend/src/pages/PresupuestosPage.tsx
+++ b/frontend/src/pages/PresupuestosPage.tsx
@@ -1,0 +1,323 @@
+import { useState } from 'react'
+import { Plus, Target } from 'lucide-react'
+import axios from 'axios'
+import { Button } from '@/components/ui/button'
+import { PresupuestoCard } from '@/features/presupuestos/components/PresupuestoCard'
+import { PresupuestoModal } from '@/features/presupuestos/components/PresupuestoModal'
+import type { PresupuestoFormData } from '@/features/presupuestos/components/PresupuestoForm'
+import {
+  usePresupuestosEstado,
+  useCreatePresupuesto,
+  useUpdatePresupuesto,
+  useDeletePresupuesto,
+} from '@/hooks/usePresupuestos'
+import { useCategorias } from '@/hooks/useCategorias'
+import type { PresupuestoEstado } from '@/types/presupuesto'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const MESES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+]
+
+function getDefaultMesYear(): { mes: number; year: number } {
+  const now = new Date()
+  return { mes: now.getMonth() + 1, year: now.getFullYear() }
+}
+
+function getYearOptions(currentYear: number): number[] {
+  return [currentYear - 1, currentYear, currentYear + 1]
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+function SkeletonCard(): JSX.Element {
+  return (
+    <div className="finza-card animate-pulse">
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <div className="h-4 w-32 bg-gray-200 rounded" />
+        <div className="h-5 w-16 bg-gray-200 rounded-full" />
+      </div>
+      <div className="flex justify-between mb-2">
+        <div className="h-6 w-24 bg-gray-200 rounded" />
+        <div className="h-4 w-20 bg-gray-200 rounded" />
+      </div>
+      <div className="h-2.5 w-full bg-gray-200 rounded-full" />
+      <div className="h-3 w-12 bg-gray-200 rounded mt-1" />
+    </div>
+  )
+}
+
+function EmptyState(): JSX.Element {
+  return (
+    <div className="col-span-2 flex flex-col items-center justify-center py-16 text-center">
+      <Target size={48} className="text-gray-300 mb-4" aria-hidden="true" />
+      <p className="text-sm font-medium text-gray-500">
+        No hay presupuestos asignados para este mes
+      </p>
+      <p className="text-xs text-gray-400 mt-1">
+        Crea tu primer presupuesto con el boton &ldquo;+ Nuevo&rdquo;
+      </p>
+    </div>
+  )
+}
+
+// ─── Main page ───────────────────────────────────────────────────────────────
+
+export function PresupuestosPage(): JSX.Element {
+  const defaults = getDefaultMesYear()
+  const [mes, setMes] = useState<number>(defaults.mes)
+  const [year, setYear] = useState<number>(defaults.year)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [editingEstado, setEditingEstado] = useState<PresupuestoEstado | null>(null)
+  const [preselectedCategoriaId, setPreselectedCategoriaId] = useState<string | undefined>(undefined)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const { data: estadoList = [], isLoading, isError } = usePresupuestosEstado(mes, year)
+  const { data: todasCategorias = [] } = useCategorias()
+
+  const createPresupuesto = useCreatePresupuesto(mes, year)
+  const updatePresupuesto = useUpdatePresupuesto(mes, year)
+  const deletePresupuesto = useDeletePresupuesto(mes, year)
+
+  const categoriasConPresupuestoIds = new Set(estadoList.map((e) => e.categoria_id))
+
+  const categoriasSinPresupuesto = todasCategorias.filter(
+    (cat) =>
+      (cat.tipo === 'egreso' || cat.tipo === 'ambos') &&
+      !categoriasConPresupuestoIds.has(cat.id)
+  )
+
+  const handleOpenCreate = (): void => {
+    setPreselectedCategoriaId(undefined)
+    setFormError(null)
+    setIsModalOpen(true)
+  }
+
+  const handleOpenAsignar = (categoriaId: string): void => {
+    setPreselectedCategoriaId(categoriaId)
+    setFormError(null)
+    setIsModalOpen(true)
+  }
+
+  const handleOpenEdit = (estado: PresupuestoEstado): void => {
+    setEditingEstado(estado)
+    setFormError(null)
+  }
+
+  const handleCloseModal = (): void => {
+    setIsModalOpen(false)
+    setPreselectedCategoriaId(undefined)
+    setFormError(null)
+  }
+
+  const handleCloseEdit = (): void => {
+    setEditingEstado(null)
+    setFormError(null)
+  }
+
+  const handleCreate = async (data: PresupuestoFormData): Promise<void> => {
+    setFormError(null)
+    try {
+      await createPresupuesto.mutateAsync({
+        categoria_id: data.categoria_id,
+        mes,
+        year,
+        monto_limite: data.monto_limite,
+      })
+      handleCloseModal()
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 409) {
+        setFormError('Ya existe un presupuesto para esta categoria en este mes')
+      } else {
+        setFormError('Error al crear el presupuesto. Intenta de nuevo.')
+      }
+    }
+  }
+
+  const handleUpdate = async (data: PresupuestoFormData): Promise<void> => {
+    if (!editingEstado) return
+    setFormError(null)
+    try {
+      await updatePresupuesto.mutateAsync({
+        id: editingEstado.id,
+        monto_limite: data.monto_limite,
+      })
+      handleCloseEdit()
+    } catch (_error) {
+      setFormError('Error al actualizar el presupuesto. Intenta de nuevo.')
+    }
+  }
+
+  const handleDelete = async (): Promise<void> => {
+    if (!editingEstado) return
+    if (window.confirm('Eliminar este presupuesto?')) {
+      await deletePresupuesto.mutateAsync(editingEstado.id)
+      handleCloseEdit()
+    }
+  }
+
+  const currentYear = defaults.year
+  const yearOptions = getYearOptions(currentYear)
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Presupuestos</h1>
+          <p className="text-gray-500 text-sm mt-1">
+            Controla tus limites de gasto por categoria
+          </p>
+        </div>
+        <Button onClick={handleOpenCreate} variant="default">
+          <Plus size={18} className="mr-2" />
+          Nuevo
+        </Button>
+      </div>
+
+      {/* Selector de mes / año */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="mes-selector"
+            className="text-xs text-gray-500 font-medium"
+          >
+            Mes
+          </label>
+          <select
+            id="mes-selector"
+            value={mes}
+            onChange={(e) => setMes(Number(e.target.value))}
+            className="finza-input py-1.5 pr-8 text-sm"
+          >
+            {MESES.map((nombre, idx) => (
+              <option key={idx + 1} value={idx + 1}>
+                {nombre}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="year-selector"
+            className="text-xs text-gray-500 font-medium"
+          >
+            Año
+          </label>
+          <select
+            id="year-selector"
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+            className="finza-input py-1.5 pr-8 text-sm"
+          >
+            {yearOptions.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Error state */}
+      {isError && (
+        <p className="text-sm text-gray-400 text-center py-4 mb-4">
+          El servidor no esta disponible. Los presupuestos se mostraran cuando
+          el backend responda.
+        </p>
+      )}
+
+      {/* Seccion: Con presupuesto */}
+      {!isError && (
+        <>
+          <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">
+            Con presupuesto asignado
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+            {isLoading && (
+              <>
+                <SkeletonCard />
+                <SkeletonCard />
+                <SkeletonCard />
+              </>
+            )}
+            {!isLoading && estadoList.length === 0 && <EmptyState />}
+            {!isLoading &&
+              estadoList.map((estado) => (
+                <PresupuestoCard
+                  key={estado.id}
+                  estado={estado}
+                  onClick={handleOpenEdit}
+                />
+              ))}
+          </div>
+
+          {/* Seccion: Sin presupuesto */}
+          {!isLoading && categoriasSinPresupuesto.length > 0 && (
+            <>
+              <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">
+                Sin presupuesto
+              </h2>
+              <div className="finza-card p-0 overflow-hidden">
+                {categoriasSinPresupuesto.map((cat, idx) => (
+                  <div
+                    key={cat.id}
+                    className={`flex items-center justify-between px-4 py-3 ${
+                      idx < categoriasSinPresupuesto.length - 1
+                        ? 'border-b border-border'
+                        : ''
+                    }`}
+                  >
+                    <span className="text-sm text-gray-700">
+                      {cat.icono ? `${cat.icono} ` : ''}
+                      {cat.nombre}
+                    </span>
+                    <Button
+                      variant="secondary"
+                      onClick={() => handleOpenAsignar(cat.id)}
+                      className="text-xs py-1 px-3 h-auto"
+                    >
+                      <Plus size={13} className="mr-1" />
+                      Asignar limite
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {/* Modal crear */}
+      <PresupuestoModal
+        isOpen={isModalOpen}
+        mes={mes}
+        year={year}
+        categoriaIdInicial={preselectedCategoriaId}
+        errorMessage={formError}
+        onClose={handleCloseModal}
+        onSubmit={handleCreate}
+        isLoading={createPresupuesto.isPending}
+      />
+
+      {/* Modal editar */}
+      {editingEstado && (
+        <PresupuestoModal
+          isOpen={true}
+          mes={mes}
+          year={year}
+          categoriaIdInicial={editingEstado.categoria_id}
+          montoLimiteInicial={editingEstado.monto_limite}
+          isEditing={true}
+          errorMessage={formError}
+          onClose={handleCloseEdit}
+          onSubmit={handleUpdate}
+          onDelete={handleDelete}
+          isLoading={updatePresupuesto.isPending}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/types/presupuesto.ts
+++ b/frontend/src/types/presupuesto.ts
@@ -1,0 +1,33 @@
+export interface Presupuesto {
+  id: string
+  user_id: string
+  categoria_id: string
+  mes: number
+  year: number
+  monto_limite: number
+  created_at: string
+  updated_at: string
+}
+
+export interface PresupuestoCreate {
+  categoria_id: string
+  mes: number
+  year: number
+  monto_limite: number
+}
+
+export interface PresupuestoUpdate {
+  monto_limite: number
+}
+
+export interface PresupuestoEstado {
+  id: string
+  categoria_id: string
+  categoria_nombre: string
+  mes: number
+  year: number
+  monto_limite: number
+  gasto_actual: number
+  porcentaje_usado: number
+  alerta: boolean
+}


### PR DESCRIPTION
Closes #49

## Changes
- `frontend/src/types/presupuesto.ts` — interfaces TypeScript: `Presupuesto`, `PresupuestoCreate`, `PresupuestoUpdate`, `PresupuestoEstado`
- `frontend/src/lib/api/presupuestos.ts` — cliente API para todos los endpoints del backend (#48)
- `frontend/src/hooks/usePresupuestos.ts` — hooks React Query: `usePresupuestosEstado`, `useCreatePresupuesto`, `useUpdatePresupuesto`, `useDeletePresupuesto`
- `frontend/src/features/presupuestos/components/BudgetProgressBar.tsx` — barra de progreso con colores dinamicos (verde/amarillo/rojo segun umbral)
- `frontend/src/features/presupuestos/components/PresupuestoCard.tsx` — tarjeta con monto gastado vs limite, progress bar, badges Alerta/Excedido
- `frontend/src/features/presupuestos/components/PresupuestoForm.tsx` — formulario Zod + React Hook Form con selector de categoria (solo egreso/ambos)
- `frontend/src/features/presupuestos/components/PresupuestoModal.tsx` — modal para crear y editar, con boton Eliminar integrado en edicion
- `frontend/src/pages/PresupuestosPage.tsx` — pagina principal con: selector mes/año, grid con presupuestos, seccion "Sin presupuesto" con boton Asignar limite
- `frontend/src/App.tsx` — reemplaza placeholder por `<PresupuestosPage />`

## Progress bar colors
- Verde (`bg-prosperity-green`): porcentaje_usado < 80%
- Amarillo (`bg-golden-flow`): 80% <= porcentaje_usado < 100%
- Rojo (`bg-alert-red`): porcentaje_usado >= 100%

## Error handling
- 409 Conflict en POST muestra mensaje inline: "Ya existe un presupuesto para esta categoria en este mes"
- Error de red muestra estado degradado sin bloquear la UI

## Tests
- 32 tests nuevos, 88/88 passing en suite completa
- `BudgetProgressBar.test.tsx`: 11 tests (colores, aria, caps)
- `PresupuestoCard.test.tsx`: 8 tests (badges, click, progreso)
- `PresupuestosPage.test.tsx`: 13 tests (loading, error, empty, modales, filtros)

## TypeScript
- `npx tsc --noEmit` — 0 errores
- Strict mode, 0 usos de `any`