### PR TITLE
feat(dashboard): implement v2 with full financial overview

### DIFF
--- a/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DashboardPage } from '@/pages/DashboardPage'
+import type { DashboardV2Response } from '@/types/dashboard'
+
+vi.mock('@/hooks/useDashboardV2', () => ({
+  useDashboardV2: vi.fn(),
+}))
+
+import { useDashboardV2 } from '@/hooks/useDashboardV2'
+
+const mockData: DashboardV2Response = {
+  resumen_financiero: {
+    ingresos_mes: 50000,
+    egresos_mes: 30000,
+    balance_mes: 20000,
+    tasa_ahorro: 40,
+    ingresos_mes_anterior: 45000,
+    egresos_mes_anterior: 28000,
+    variacion_ingresos_pct: 11.1,
+    variacion_egresos_pct: 7.1,
+  },
+  presupuestos_estado: [
+    {
+      categoria: 'Alimentacion',
+      monto_presupuestado: 10000,
+      gasto_actual: 7000,
+      porcentaje_usado: 70,
+      alerta: false,
+    },
+  ],
+  metas_activas: [
+    {
+      nombre: 'Fondo de emergencia',
+      monto_objetivo: 100000,
+      monto_actual: 50000,
+      porcentaje_completado: 50,
+      fecha_limite: '2026-12-31',
+    },
+  ],
+  prestamos_activos: {
+    total_deuda: 150000,
+    count: 2,
+    proximo_vencimiento: '2026-04-15',
+  },
+  ultimas_transacciones: [
+    {
+      tipo: 'ingreso',
+      descripcion: 'Salario',
+      monto: 50000,
+      fecha: '2026-03-01',
+      categoria: 'Salarios',
+    },
+    {
+      tipo: 'egreso',
+      descripcion: 'Supermercado',
+      monto: 3000,
+      fecha: '2026-03-05',
+      categoria: 'Alimentacion',
+    },
+  ],
+  egresos_por_categoria: [
+    { categoria: 'Alimentacion', total: 7000, porcentaje: 46.7 },
+    { categoria: 'Transporte', total: 3000, porcentaje: 20 },
+  ],
+}
+
+function setupMock({
+  data = mockData,
+  isLoading = false,
+  isError = false,
+  error = null,
+}: {
+  data?: DashboardV2Response | undefined
+  isLoading?: boolean
+  isError?: boolean
+  error?: Error | null
+} = {}) {
+  vi.mocked(useDashboardV2).mockReturnValue({
+    data,
+    isLoading,
+    isError,
+    isPending: isLoading,
+    isSuccess: !isLoading && !isError,
+    error,
+  } as ReturnType<typeof useDashboardV2>)
+}
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMock()
+  })
+
+  it('renders page title', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+  })
+
+  it('renders month selector', () => {
+    render(<DashboardPage />)
+    expect(screen.getByLabelText('Mes')).toBeInTheDocument()
+  })
+
+  it('renders year selector', () => {
+    render(<DashboardPage />)
+    expect(screen.getByLabelText('Ano')).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton state with 4 KPI cards', () => {
+    setupMock({ isLoading: true, data: undefined })
+    render(<DashboardPage />)
+    const pulsingElements = document.querySelectorAll('.animate-pulse')
+    expect(pulsingElements.length).toBeGreaterThan(0)
+  })
+
+  it('shows error alert when isError is true', () => {
+    setupMock({ isError: true, error: new Error('Network error'), data: undefined })
+    render(<DashboardPage />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Network error')).toBeInTheDocument()
+  })
+
+  it('shows fallback error message when error has no message', () => {
+    setupMock({ isError: true, error: null, data: undefined })
+    render(<DashboardPage />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/error al cargar el dashboard/i)).toBeInTheDocument()
+  })
+
+  it('renders ingresos KPI with data', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Ingresos del mes')).toBeInTheDocument()
+    expect(screen.getAllByText(/50,000/).length).toBeGreaterThan(0)
+  })
+
+  it('renders egresos KPI with data', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Egresos del mes')).toBeInTheDocument()
+  })
+
+  it('renders balance KPI with data', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Balance del mes')).toBeInTheDocument()
+  })
+
+  it('renders tasa de ahorro KPI', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Tasa de ahorro')).toBeInTheDocument()
+    expect(screen.getByText('40.0%')).toBeInTheDocument()
+  })
+
+  it('renders recent transactions', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Salario')).toBeInTheDocument()
+    expect(screen.getByText('Supermercado')).toBeInTheDocument()
+  })
+
+  it('renders category breakdown bars', () => {
+    render(<DashboardPage />)
+    expect(screen.getAllByText('Alimentacion').length).toBeGreaterThan(0)
+    expect(screen.getByText('Transporte')).toBeInTheDocument()
+  })
+
+  it('renders presupuestos section', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Presupuestos')).toBeInTheDocument()
+  })
+
+  it('renders metas activas section', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Metas activas')).toBeInTheDocument()
+    expect(screen.getByText('Fondo de emergencia')).toBeInTheDocument()
+  })
+
+  it('renders prestamos activos with deuda total', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Prestamos activos')).toBeInTheDocument()
+    expect(screen.getByText(/150,000/)).toBeInTheDocument()
+  })
+
+  it('shows "Sin prestamos activos" when count is 0', () => {
+    setupMock({
+      data: {
+        ...mockData,
+        prestamos_activos: { total_deuda: 0, count: 0, proximo_vencimiento: null },
+      },
+    })
+    render(<DashboardPage />)
+    expect(screen.getByText('Sin prestamos activos')).toBeInTheDocument()
+  })
+
+  it('shows empty state for transactions when list is empty', () => {
+    setupMock({ data: { ...mockData, ultimas_transacciones: [] } })
+    render(<DashboardPage />)
+    expect(screen.getAllByText(/no hay datos para este periodo/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows empty state for metas when list is empty', () => {
+    setupMock({ data: { ...mockData, metas_activas: [] } })
+    render(<DashboardPage />)
+    expect(screen.getAllByText(/no hay datos para este periodo/i).length).toBeGreaterThan(0)
+  })
+
+  it('changes mes when selector changes', () => {
+    render(<DashboardPage />)
+    const mesSelect = screen.getByLabelText('Mes')
+    fireEvent.change(mesSelect, { target: { value: '6' } })
+    expect((mesSelect as HTMLSelectElement).value).toBe('6')
+  })
+
+  it('changes year when selector changes', () => {
+    render(<DashboardPage />)
+    const yearSelect = screen.getByLabelText('Ano')
+    fireEvent.change(yearSelect, { target: { value: '2025' } })
+    expect((yearSelect as HTMLSelectElement).value).toBe('2025')
+  })
+
+  it('does not show error alert when isError is false', () => {
+    render(<DashboardPage />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/dashboard/__tests__/EgresoCategoriaBar.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/EgresoCategoriaBar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { EgresoCategoriaBar } from '../components/v2/EgresoCategoriaBar'
+import type { EgresoCategoria } from '@/types/dashboard'
+
+const mockItem: EgresoCategoria = {
+  categoria: 'Alimentacion',
+  total: 5000,
+  porcentaje: 35.5,
+}
+
+describe('EgresoCategoriaBar', () => {
+  it('renders category name', () => {
+    render(<EgresoCategoriaBar item={mockItem} />)
+    expect(screen.getByText('Alimentacion')).toBeInTheDocument()
+  })
+
+  it('renders percentage label', () => {
+    render(<EgresoCategoriaBar item={mockItem} />)
+    expect(screen.getByText('35.5%')).toBeInTheDocument()
+  })
+
+  it('renders total amount formatted', () => {
+    render(<EgresoCategoriaBar item={mockItem} />)
+    expect(screen.getByText(/5,000/)).toBeInTheDocument()
+  })
+
+  it('renders progress bar with correct aria attributes', () => {
+    render(<EgresoCategoriaBar item={mockItem} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '36')
+    expect(bar).toHaveAttribute('aria-valuemin', '0')
+    expect(bar).toHaveAttribute('aria-valuemax', '100')
+  })
+
+  it('caps progress bar width at 100% for values over 100', () => {
+    render(<EgresoCategoriaBar item={{ ...mockItem, porcentaje: 150 }} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.style.width).toBe('100%')
+  })
+
+  it('renders zero percentage correctly', () => {
+    render(<EgresoCategoriaBar item={{ ...mockItem, porcentaje: 0 }} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.style.width).toBe('0%')
+  })
+})

--- a/frontend/src/features/dashboard/__tests__/KpiCard.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/KpiCard.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { KpiCard } from '../components/v2/KpiCard'
+import { TrendingUp } from 'lucide-react'
+
+const defaultProps = {
+  title: 'Ingresos del mes',
+  value: 'RD$10,000.00',
+  icon: <TrendingUp size={18} />,
+  iconBg: '#00B05020',
+}
+
+describe('KpiCard', () => {
+  it('renders correctly with default props', () => {
+    render(<KpiCard {...defaultProps} />)
+    expect(screen.getByText('Ingresos del mes')).toBeInTheDocument()
+    expect(screen.getByText('RD$10,000.00')).toBeInTheDocument()
+  })
+
+  it('renders subtitle when provided', () => {
+    render(<KpiCard {...defaultProps} subtitle="vs. mes anterior" />)
+    expect(screen.getByText('vs. mes anterior')).toBeInTheDocument()
+  })
+
+  it('shows positive variation with green color and up arrow', () => {
+    render(<KpiCard {...defaultProps} variationPct={15.5} />)
+    const badge = screen.getByLabelText(/incremento de 15.5%/i)
+    expect(badge).toBeInTheDocument()
+    expect(badge.className).toContain('text-prosperity-green')
+  })
+
+  it('shows negative variation with red color and down arrow', () => {
+    render(<KpiCard {...defaultProps} variationPct={-8.3} />)
+    const badge = screen.getByLabelText(/reduccion de 8.3%/i)
+    expect(badge).toBeInTheDocument()
+    expect(badge.className).toContain('text-alert-red')
+  })
+
+  it('shows dash when variation is zero', () => {
+    render(<KpiCard {...defaultProps} variationPct={0} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('does not render variation when variationPct is undefined', () => {
+    render(<KpiCard {...defaultProps} />)
+    expect(screen.queryByText('—')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/incremento/i)).not.toBeInTheDocument()
+  })
+
+  it('applies custom value color class', () => {
+    const { container } = render(
+      <KpiCard {...defaultProps} valueColorClass="text-alert-red" />
+    )
+    const valueEl = container.querySelector('.text-alert-red')
+    expect(valueEl).toBeInTheDocument()
+  })
+
+  it('renders skeleton correctly', () => {
+    render(<KpiCard.Skeleton />)
+    const animatedElements = document.querySelectorAll('.animate-pulse')
+    expect(animatedElements.length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/features/dashboard/__tests__/MetaProgressItem.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/MetaProgressItem.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MetaProgressItem } from '../components/v2/MetaProgressItem'
+import type { MetaActivaV2 } from '@/types/dashboard'
+
+const mockMeta: MetaActivaV2 = {
+  nombre: 'Fondo de emergencia',
+  monto_objetivo: 100000,
+  monto_actual: 45000,
+  porcentaje_completado: 45,
+  fecha_limite: '2026-12-31',
+}
+
+const mockMetaSinFecha: MetaActivaV2 = {
+  ...mockMeta,
+  nombre: 'Vacaciones',
+  fecha_limite: null,
+}
+
+const mockMetaCompleta: MetaActivaV2 = {
+  ...mockMeta,
+  nombre: 'Meta completada',
+  monto_actual: 100000,
+  porcentaje_completado: 100,
+}
+
+describe('MetaProgressItem', () => {
+  it('renders meta name', () => {
+    render(<MetaProgressItem meta={mockMeta} />)
+    expect(screen.getByText('Fondo de emergencia')).toBeInTheDocument()
+  })
+
+  it('renders percentage label', () => {
+    render(<MetaProgressItem meta={mockMeta} />)
+    expect(screen.getByText('45%')).toBeInTheDocument()
+  })
+
+  it('renders progress bar with correct aria attributes', () => {
+    render(<MetaProgressItem meta={mockMeta} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '45')
+    expect(bar).toHaveAttribute('aria-valuemin', '0')
+    expect(bar).toHaveAttribute('aria-valuemax', '100')
+  })
+
+  it('shows fecha limite when provided', () => {
+    render(<MetaProgressItem meta={mockMeta} />)
+    expect(screen.getByText(/limite/i)).toBeInTheDocument()
+  })
+
+  it('does not show fecha limite when null', () => {
+    render(<MetaProgressItem meta={mockMetaSinFecha} />)
+    expect(screen.queryByText(/limite/i)).not.toBeInTheDocument()
+  })
+
+  it('shows monto_actual and monto_objetivo', () => {
+    render(<MetaProgressItem meta={mockMeta} />)
+    expect(screen.getByText(/45,000/)).toBeInTheDocument()
+    expect(screen.getByText(/100,000/)).toBeInTheDocument()
+  })
+
+  it('renders green bar when 100% completed', () => {
+    const { container } = render(<MetaProgressItem meta={mockMetaCompleta} />)
+    const bar = container.querySelector('.bg-prosperity-green')
+    expect(bar).toBeInTheDocument()
+  })
+
+  it('caps progress at 100% even if value exceeds 100', () => {
+    render(<MetaProgressItem meta={{ ...mockMeta, porcentaje_completado: 120 }} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.style.width).toBe('100%')
+  })
+})

--- a/frontend/src/features/dashboard/__tests__/TransaccionItem.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/TransaccionItem.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { TransaccionItem } from '../components/v2/TransaccionItem'
+import type { UltimaTransaccionV2 } from '@/types/dashboard'
+
+const ingresoMock: UltimaTransaccionV2 = {
+  tipo: 'ingreso',
+  descripcion: 'Salario mensual',
+  monto: 50000,
+  fecha: '2026-03-01',
+  categoria: 'Salarios',
+}
+
+const egresoMock: UltimaTransaccionV2 = {
+  tipo: 'egreso',
+  descripcion: 'Supermercado',
+  monto: 2500.5,
+  fecha: '2026-03-05',
+  categoria: 'Alimentacion',
+}
+
+const egresoSinCategoria: UltimaTransaccionV2 = {
+  tipo: 'egreso',
+  descripcion: 'Gasto sin categoria',
+  monto: 500,
+  fecha: '2026-03-10',
+  categoria: null,
+}
+
+describe('TransaccionItem', () => {
+  it('renders description correctly', () => {
+    render(<TransaccionItem transaccion={ingresoMock} />)
+    expect(screen.getByText('Salario mensual')).toBeInTheDocument()
+  })
+
+  it('shows INGRESO badge for income transactions', () => {
+    render(<TransaccionItem transaccion={ingresoMock} />)
+    expect(screen.getByText('INGRESO')).toBeInTheDocument()
+  })
+
+  it('shows EGRESO badge for expense transactions', () => {
+    render(<TransaccionItem transaccion={egresoMock} />)
+    expect(screen.getByText('EGRESO')).toBeInTheDocument()
+  })
+
+  it('shows categoria when provided', () => {
+    render(<TransaccionItem transaccion={egresoMock} />)
+    expect(screen.getByText(/alimentacion/i)).toBeInTheDocument()
+  })
+
+  it('does not show categoria section when null', () => {
+    render(<TransaccionItem transaccion={egresoSinCategoria} />)
+    expect(screen.queryByText(/alimentacion/i)).not.toBeInTheDocument()
+  })
+
+  it('formats monto as currency', () => {
+    render(<TransaccionItem transaccion={ingresoMock} />)
+    expect(screen.getByText(/50,000/)).toBeInTheDocument()
+  })
+
+  it('shows + prefix for ingresos', () => {
+    render(<TransaccionItem transaccion={ingresoMock} />)
+    const montoEl = screen.getByText(/\+RD\$/)
+    expect(montoEl).toBeInTheDocument()
+  })
+
+  it('shows - prefix for egresos', () => {
+    render(<TransaccionItem transaccion={egresoMock} />)
+    const montoEl = screen.getByText(/-RD\$/)
+    expect(montoEl).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/dashboard/components/v2/EgresoCategoriaBar.tsx
+++ b/frontend/src/features/dashboard/components/v2/EgresoCategoriaBar.tsx
@@ -1,0 +1,36 @@
+import { formatMoney } from '@/lib/utils'
+import type { EgresoCategoria } from '@/types/dashboard'
+
+interface EgresoCategoriaBarProps {
+  item: EgresoCategoria
+}
+
+export function EgresoCategoriaBar({ item }: EgresoCategoriaBarProps): JSX.Element {
+  const { categoria, total, porcentaje } = item
+  const pct = Math.min(100, Math.max(0, porcentaje))
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium text-gray-700 truncate mr-2">{categoria}</span>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="text-xs text-gray-400">{pct.toFixed(1)}%</span>
+          <span className="text-sm font-semibold font-mono text-alert-red">
+            {formatMoney(total)}
+          </span>
+        </div>
+      </div>
+      <div className="w-full bg-gray-100 rounded-full h-2 overflow-hidden">
+        <div
+          className="bg-finza-blue h-2 rounded-full transition-all duration-300"
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={Math.round(pct)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${categoria}: ${pct.toFixed(1)}% del total de egresos`}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/dashboard/components/v2/KpiCard.tsx
+++ b/frontend/src/features/dashboard/components/v2/KpiCard.tsx
@@ -1,0 +1,98 @@
+import { TrendingUp, TrendingDown } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+interface KpiCardProps {
+  title: string
+  value: string
+  variationPct?: number
+  icon: React.ReactNode
+  iconBg: string
+  valueColorClass?: string
+  subtitle?: string
+}
+
+function VariationBadge({ pct }: { pct: number }): JSX.Element {
+  if (pct === 0) {
+    return <span className="text-xs text-gray-400 font-medium">—</span>
+  }
+
+  const isPositive = pct > 0
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-0.5 text-xs font-medium',
+        isPositive ? 'text-prosperity-green' : 'text-alert-red'
+      )}
+      aria-label={`${isPositive ? 'Incremento' : 'Reduccion'} de ${Math.abs(pct).toFixed(1)}%`}
+    >
+      {isPositive ? (
+        <TrendingUp size={12} aria-hidden="true" />
+      ) : (
+        <TrendingDown size={12} aria-hidden="true" />
+      )}
+      {Math.abs(pct).toFixed(1)}%
+    </span>
+  )
+}
+
+function KpiCardSkeleton(): JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-28 bg-flow-light rounded animate-pulse" />
+          <div className="w-9 h-9 bg-flow-light rounded-lg animate-pulse" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="h-8 w-36 bg-flow-light rounded animate-pulse" />
+        <div className="h-3 w-24 bg-flow-light rounded animate-pulse mt-2" />
+      </CardContent>
+    </Card>
+  )
+}
+
+export function KpiCard({
+  title,
+  value,
+  variationPct,
+  icon,
+  iconBg,
+  valueColorClass = 'text-gray-900',
+  subtitle,
+}: KpiCardProps): JSX.Element {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium text-gray-500">
+            {title}
+          </CardTitle>
+          <div
+            className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
+            style={{ backgroundColor: iconBg }}
+            aria-hidden="true"
+          >
+            {icon}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className={cn('text-2xl font-bold font-mono', valueColorClass)}>
+          {value}
+        </p>
+        <div className="flex items-center gap-2 mt-1">
+          {variationPct !== undefined && (
+            <VariationBadge pct={variationPct} />
+          )}
+          {subtitle && (
+            <p className="text-xs text-gray-400">{subtitle}</p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+KpiCard.Skeleton = KpiCardSkeleton

--- a/frontend/src/features/dashboard/components/v2/MetaProgressItem.tsx
+++ b/frontend/src/features/dashboard/components/v2/MetaProgressItem.tsx
@@ -1,0 +1,46 @@
+import { formatDate, formatMoney } from '@/lib/utils'
+import type { MetaActivaV2 } from '@/types/dashboard'
+
+interface MetaProgressItemProps {
+  meta: MetaActivaV2
+}
+
+export function MetaProgressItem({ meta }: MetaProgressItemProps): JSX.Element {
+  const { nombre, monto_objetivo, monto_actual, porcentaje_completado, fecha_limite } = meta
+  const pct = Math.min(100, Math.max(0, porcentaje_completado))
+
+  const barColor =
+    pct >= 100
+      ? 'bg-prosperity-green'
+      : pct >= 60
+        ? 'bg-finza-blue-light'
+        : 'bg-finza-blue'
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-sm font-medium text-gray-800 truncate">{nombre}</span>
+        <span className="text-xs font-semibold text-finza-blue flex-shrink-0">
+          {pct.toFixed(0)}%
+        </span>
+      </div>
+      <div className="w-full bg-gray-100 rounded-full h-1.5 overflow-hidden">
+        <div
+          className={`${barColor} h-1.5 rounded-full transition-all duration-300`}
+          style={{ width: `${pct}%` }}
+          role="progressbar"
+          aria-valuenow={Math.round(pct)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Meta ${nombre}: ${pct.toFixed(0)}% completada`}
+        />
+      </div>
+      <div className="flex items-center justify-between text-xs text-gray-400">
+        <span>{formatMoney(monto_actual)} / {formatMoney(monto_objetivo)}</span>
+        {fecha_limite && (
+          <span>Limite: {formatDate(fecha_limite)}</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/dashboard/components/v2/TransaccionItem.tsx
+++ b/frontend/src/features/dashboard/components/v2/TransaccionItem.tsx
@@ -1,0 +1,57 @@
+import { cn } from '@/lib/utils'
+import { formatDate, formatMoney } from '@/lib/utils'
+import type { UltimaTransaccionV2 } from '@/types/dashboard'
+
+interface TransaccionItemProps {
+  transaccion: UltimaTransaccionV2
+}
+
+export function TransaccionItem({ transaccion }: TransaccionItemProps): JSX.Element {
+  const { tipo, descripcion, monto, fecha, categoria } = transaccion
+  const isIngreso = tipo === 'ingreso'
+
+  return (
+    <div className="flex items-center justify-between py-3 border-b border-border last:border-0">
+      <div className="flex items-center gap-3 flex-1 min-w-0">
+        <div
+          className={cn(
+            'w-2 h-2 rounded-full flex-shrink-0',
+            isIngreso ? 'bg-prosperity-green' : 'bg-alert-red'
+          )}
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-900 truncate">
+            {descripcion}
+          </p>
+          <p className="text-xs text-gray-400 flex items-center gap-1">
+            <span
+              className={cn(
+                'inline-block px-1.5 py-0.5 rounded text-[10px] font-medium',
+                isIngreso
+                  ? 'bg-prosperity-green/10 text-prosperity-green'
+                  : 'bg-alert-red/10 text-alert-red'
+              )}
+            >
+              {isIngreso ? 'INGRESO' : 'EGRESO'}
+            </span>
+            {categoria && (
+              <span>{categoria} &middot; </span>
+            )}
+            <span>{formatDate(fecha)}</span>
+          </p>
+        </div>
+      </div>
+      <div className="ml-4 flex-shrink-0">
+        <span
+          className={cn(
+            'text-sm font-semibold font-mono',
+            isIngreso ? 'text-prosperity-green' : 'text-alert-red'
+          )}
+        >
+          {isIngreso ? '+' : '-'}{formatMoney(Math.abs(monto))}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useDashboardV2.ts
+++ b/frontend/src/hooks/useDashboardV2.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import { getDashboardV2 } from '@/lib/api/dashboard'
+import type { DashboardV2Response } from '@/types/dashboard'
+
+interface DashboardV2Params {
+  mes: number
+  year: number
+}
+
+export function useDashboardV2({ mes, year }: DashboardV2Params) {
+  return useQuery<DashboardV2Response, Error>({
+    queryKey: ['dashboard-v2', mes, year],
+    queryFn: () => getDashboardV2(mes, year),
+    staleTime: 2 * 60 * 1000,
+  })
+}

--- a/frontend/src/lib/api/dashboard.ts
+++ b/frontend/src/lib/api/dashboard.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '@/lib/api'
+import type { DashboardV2Response } from '@/types/dashboard'
+
+export async function getDashboardV2(
+  mes: number,
+  year: number
+): Promise<DashboardV2Response> {
+  const { data } = await apiClient.get<DashboardV2Response>(
+    `/dashboard/v2?mes=${mes}&year=${year}`
+  )
+  return data
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,48 +1,46 @@
 import { useState } from 'react'
-import { AlertCircle } from 'lucide-react'
+import {
+  TrendingUp,
+  TrendingDown,
+  Wallet,
+  Target,
+  AlertCircle,
+  CreditCard,
+  CalendarClock,
+} from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { useDashboard } from '@/features/dashboard/hooks/useDashboard'
-import { KpiCards } from '@/features/dashboard/components/KpiCards'
-import { CategoryPieChart } from '@/features/dashboard/components/CategoryPieChart'
-import { MonthlyChart } from '@/features/dashboard/components/MonthlyChart'
-import { RecentTransactions } from '@/features/dashboard/components/RecentTransactions'
-import { MonthlySummary } from '@/features/dashboard/components/MonthlySummary'
+import { useDashboardV2 } from '@/hooks/useDashboardV2'
+import { KpiCard } from '@/features/dashboard/components/v2/KpiCard'
+import { TransaccionItem } from '@/features/dashboard/components/v2/TransaccionItem'
+import { EgresoCategoriaBar } from '@/features/dashboard/components/v2/EgresoCategoriaBar'
+import { MetaProgressItem } from '@/features/dashboard/components/v2/MetaProgressItem'
+import { BudgetProgressBar } from '@/features/presupuestos/components/BudgetProgressBar'
+import { formatDate, formatMoney } from '@/lib/utils'
+
+const MONTH_NAMES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+]
 
 function getInitialPeriod(): { mes: number; year: number } {
   const now = new Date()
   return { mes: now.getMonth() + 1, year: now.getFullYear() }
 }
 
-function prevMonth(mes: number, year: number): { mes: number; year: number } {
-  if (mes === 1) return { mes: 12, year: year - 1 }
-  return { mes: mes - 1, year }
-}
-
-function nextMonth(mes: number, year: number): { mes: number; year: number } {
-  if (mes === 12) return { mes: 1, year: year + 1 }
-  return { mes: mes + 1, year }
+function buildYearOptions(currentYear: number): number[] {
+  return [currentYear - 2, currentYear - 1, currentYear, currentYear + 1, currentYear + 2]
 }
 
 export function DashboardPage(): JSX.Element {
-  const [period, setPeriod] = useState(getInitialPeriod)
+  const now = new Date()
+  const currentYear = now.getFullYear()
 
-  const { data, isLoading, isError, error } = useDashboard({
-    mes: period.mes,
-    year: period.year,
-  })
+  const [mes, setMes] = useState<number>(getInitialPeriod().mes)
+  const [year, setYear] = useState<number>(getInitialPeriod().year)
 
-  const handlePrev = (): void => {
-    setPeriod((p) => prevMonth(p.mes, p.year))
-  }
+  const { data, isLoading, isError, error } = useDashboardV2({ mes, year })
 
-  const handleNext = (): void => {
-    const now = new Date()
-    const isCurrentMonth =
-      period.mes === now.getMonth() + 1 && period.year === now.getFullYear()
-    if (!isCurrentMonth) {
-      setPeriod((p) => nextMonth(p.mes, p.year))
-    }
-  }
+  const yearOptions = buildYearOptions(currentYear)
 
   return (
     <div>
@@ -52,12 +50,43 @@ export function DashboardPage(): JSX.Element {
           <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
           <p className="text-gray-500 text-sm mt-1">Resumen financiero del mes</p>
         </div>
-        <MonthlySummary
-          mes={period.mes}
-          year={period.year}
-          onPrev={handlePrev}
-          onNext={handleNext}
-        />
+
+        {/* Month / Year selector */}
+        <div className="flex items-center gap-2">
+          <div>
+            <label htmlFor="mes-selector" className="sr-only">Mes</label>
+            <select
+              id="mes-selector"
+              aria-label="Mes"
+              value={mes}
+              onChange={(e) => setMes(Number(e.target.value))}
+              className="block w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-finza-blue focus:outline-none focus:ring-1 focus:ring-finza-blue"
+            >
+              {MONTH_NAMES.map((name, idx) => (
+                <option key={name} value={idx + 1}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="year-selector" className="sr-only">Ano</label>
+            <select
+              id="year-selector"
+              aria-label="Ano"
+              value={year}
+              onChange={(e) => setYear(Number(e.target.value))}
+              className="block w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-finza-blue focus:outline-none focus:ring-1 focus:ring-finza-blue"
+            >
+              {yearOptions.map((y) => (
+                <option key={y} value={y}>
+                  {y}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
       </div>
 
       {/* Error state */}
@@ -74,59 +103,250 @@ export function DashboardPage(): JSX.Element {
       )}
 
       {/* KPI cards */}
-      <div className="mb-8">
-        <KpiCards
-          kpis={
-            data?.kpis ?? {
-              total_ingresos: 0,
-              total_egresos: 0,
-              balance: 0,
-              ahorro_estimado: 0,
-            }
-          }
-          isLoading={isLoading}
-        />
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
+        {isLoading ? (
+          <>
+            <KpiCard.Skeleton />
+            <KpiCard.Skeleton />
+            <KpiCard.Skeleton />
+            <KpiCard.Skeleton />
+          </>
+        ) : (
+          <>
+            <KpiCard
+              title="Ingresos del mes"
+              value={formatMoney(data?.resumen_financiero.ingresos_mes ?? 0)}
+              variationPct={data?.resumen_financiero.variacion_ingresos_pct ?? 0}
+              icon={<TrendingUp size={18} style={{ color: '#00B050' }} />}
+              iconBg="#00B05020"
+              valueColorClass="text-prosperity-green"
+              subtitle="vs. mes anterior"
+            />
+            <KpiCard
+              title="Egresos del mes"
+              value={formatMoney(data?.resumen_financiero.egresos_mes ?? 0)}
+              variationPct={data?.resumen_financiero.variacion_egresos_pct ?? 0}
+              icon={<TrendingDown size={18} style={{ color: '#FF0000' }} />}
+              iconBg="#FF000020"
+              valueColorClass="text-alert-red"
+              subtitle="vs. mes anterior"
+            />
+            <KpiCard
+              title="Balance del mes"
+              value={formatMoney(Math.abs(data?.resumen_financiero.balance_mes ?? 0))}
+              icon={<Wallet size={18} style={{ color: '#366092' }} />}
+              iconBg="#36609220"
+              valueColorClass={
+                (data?.resumen_financiero.balance_mes ?? 0) >= 0
+                  ? 'text-prosperity-green'
+                  : 'text-alert-red'
+              }
+              subtitle="Ingresos - Egresos"
+            />
+            <KpiCard
+              title="Tasa de ahorro"
+              value={`${(data?.resumen_financiero.tasa_ahorro ?? 0).toFixed(1)}%`}
+              icon={<Target size={18} style={{ color: '#FFC000' }} />}
+              iconBg="#FFC00020"
+              valueColorClass="text-golden-flow"
+              subtitle="Del total de ingresos"
+            />
+          </>
+        )}
       </div>
 
-      {/* Charts row */}
+      {/* Central section: transactions + category breakdown */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        {/* Recent transactions */}
         <Card>
           <CardHeader>
-            <CardTitle>Tendencia mensual</CardTitle>
+            <CardTitle>Ultimas transacciones</CardTitle>
           </CardHeader>
           <CardContent>
-            <MonthlyChart
-              data={data?.monthly_trend ?? []}
-              isLoading={isLoading}
-            />
+            {isLoading ? (
+              <div aria-label="Cargando transacciones">
+                {[...Array(5)].map((_, i) => (
+                  <div key={i} className="py-3 border-b border-border last:border-0">
+                    <div className="h-4 w-48 bg-flow-light rounded animate-pulse mb-1" />
+                    <div className="h-3 w-32 bg-flow-light rounded animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : (data?.ultimas_transacciones ?? []).length === 0 ? (
+              <p className="text-sm text-gray-400 text-center py-8">
+                No hay datos para este periodo
+              </p>
+            ) : (
+              <div>
+                {(data?.ultimas_transacciones ?? []).slice(0, 5).map((tx, idx) => (
+                  <TransaccionItem key={idx} transaccion={tx} />
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
 
+        {/* Egresos por categoria */}
         <Card>
           <CardHeader>
             <CardTitle>Egresos por categoria</CardTitle>
           </CardHeader>
           <CardContent>
-            <CategoryPieChart
-              data={data?.categoria_breakdown ?? []}
-              isLoading={isLoading}
-            />
+            {isLoading ? (
+              <div className="space-y-4">
+                {[...Array(4)].map((_, i) => (
+                  <div key={i} className="space-y-1">
+                    <div className="h-4 w-32 bg-flow-light rounded animate-pulse" />
+                    <div className="h-2 w-full bg-flow-light rounded animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : (data?.egresos_por_categoria ?? []).length === 0 ? (
+              <p className="text-sm text-gray-400 text-center py-8">
+                No hay datos para este periodo
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {(data?.egresos_por_categoria ?? []).map((item) => (
+                  <EgresoCategoriaBar key={item.categoria} item={item} />
+                ))}
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>
 
-      {/* Recent transactions */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Ultimas transacciones</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <RecentTransactions
-            transactions={data?.recent_transactions ?? []}
-            isLoading={isLoading}
-          />
-        </CardContent>
-      </Card>
+      {/* Bottom section: budgets + goals + loans */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* Presupuestos */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Presupuestos</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                {[...Array(3)].map((_, i) => (
+                  <div key={i} className="space-y-1">
+                    <div className="h-4 w-28 bg-flow-light rounded animate-pulse" />
+                    <div className="h-2.5 w-full bg-flow-light rounded animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : (data?.presupuestos_estado ?? []).length === 0 ? (
+              <p className="text-sm text-gray-400 text-center py-6">
+                No hay datos para este periodo
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {(data?.presupuestos_estado ?? []).map((pres) => (
+                  <div key={pres.categoria} className="space-y-1">
+                    <div className="flex items-center justify-between text-sm">
+                      <span
+                        className={
+                          pres.alerta
+                            ? 'font-semibold text-alert-red'
+                            : 'font-medium text-gray-700'
+                        }
+                      >
+                        {pres.categoria}
+                      </span>
+                      <span className="text-xs text-gray-400">
+                        {pres.porcentaje_usado.toFixed(0)}%
+                      </span>
+                    </div>
+                    <BudgetProgressBar
+                      porcentaje={pres.porcentaje_usado}
+                      aria-label={`Presupuesto ${pres.categoria}: ${pres.porcentaje_usado.toFixed(0)}% usado`}
+                    />
+                    <p className="text-xs text-gray-400">
+                      {formatMoney(pres.gasto_actual)} / {formatMoney(pres.monto_presupuestado)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Metas activas */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Metas activas</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-4">
+                {[...Array(3)].map((_, i) => (
+                  <div key={i} className="space-y-1">
+                    <div className="h-4 w-28 bg-flow-light rounded animate-pulse" />
+                    <div className="h-1.5 w-full bg-flow-light rounded animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : (data?.metas_activas ?? []).length === 0 ? (
+              <p className="text-sm text-gray-400 text-center py-6">
+                No hay datos para este periodo
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {(data?.metas_activas ?? []).map((meta) => (
+                  <MetaProgressItem key={meta.nombre} meta={meta} />
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Prestamos activos */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Prestamos activos</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="space-y-3">
+                <div className="h-8 w-40 bg-flow-light rounded animate-pulse" />
+                <div className="h-4 w-24 bg-flow-light rounded animate-pulse" />
+                <div className="h-4 w-32 bg-flow-light rounded animate-pulse" />
+              </div>
+            ) : (data?.prestamos_activos.count ?? 0) === 0 ? (
+              <div className="flex flex-col items-center justify-center py-6 text-center">
+                <CreditCard size={32} className="text-gray-300 mb-2" aria-hidden="true" />
+                <p className="text-sm text-gray-400">Sin prestamos activos</p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div>
+                  <p className="text-xs text-gray-400 mb-0.5">Deuda total</p>
+                  <p className="text-2xl font-bold font-mono text-alert-red">
+                    {formatMoney(data?.prestamos_activos.total_deuda ?? 0)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <CreditCard size={14} className="text-finza-blue" aria-hidden="true" />
+                  <span>
+                    {data?.prestamos_activos.count ?? 0}{' '}
+                    {(data?.prestamos_activos.count ?? 0) === 1 ? 'prestamo' : 'prestamos'} activo
+                    {(data?.prestamos_activos.count ?? 0) !== 1 ? 's' : ''}
+                  </span>
+                </div>
+                {data?.prestamos_activos.proximo_vencimiento && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <CalendarClock size={14} className="text-golden-flow" aria-hidden="true" />
+                    <span>
+                      Proximo vencimiento:{' '}
+                      <span className="font-medium text-golden-flow">
+                        {formatDate(data.prestamos_activos.proximo_vencimiento)}
+                      </span>
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -5,6 +5,63 @@ export interface DashboardKpis {
   ahorro_estimado: number
 }
 
+// Dashboard v2 types
+export interface ResumenFinanciero {
+  ingresos_mes: number
+  egresos_mes: number
+  balance_mes: number
+  tasa_ahorro: number
+  ingresos_mes_anterior: number
+  egresos_mes_anterior: number
+  variacion_ingresos_pct: number
+  variacion_egresos_pct: number
+}
+
+export interface PresupuestoEstadoV2 {
+  categoria: string
+  monto_presupuestado: number
+  gasto_actual: number
+  porcentaje_usado: number
+  alerta: boolean
+}
+
+export interface MetaActivaV2 {
+  nombre: string
+  monto_objetivo: number
+  monto_actual: number
+  porcentaje_completado: number
+  fecha_limite: string | null
+}
+
+export interface PrestamosActivosV2 {
+  total_deuda: number
+  count: number
+  proximo_vencimiento: string | null
+}
+
+export interface UltimaTransaccionV2 {
+  tipo: 'ingreso' | 'egreso'
+  descripcion: string
+  monto: number
+  fecha: string
+  categoria: string | null
+}
+
+export interface EgresoCategoria {
+  categoria: string
+  total: number
+  porcentaje: number
+}
+
+export interface DashboardV2Response {
+  resumen_financiero: ResumenFinanciero
+  presupuestos_estado: PresupuestoEstadoV2[]
+  metas_activas: MetaActivaV2[]
+  prestamos_activos: PrestamosActivosV2
+  ultimas_transacciones: UltimaTransaccionV2[]
+  egresos_por_categoria: EgresoCategoria[]
+}
+
 export interface CategoriaBreakdown {
   categoria_id: string
   nombre: string


### PR DESCRIPTION
Closes #47

## Changes
- New types in `dashboard.ts`: `DashboardV2Response`, `ResumenFinanciero`, `MetaActivaV2`, `PresupuestoEstadoV2`, `PrestamosActivosV2`, `UltimaTransaccionV2`, `EgresoCategoria`
- New API function `getDashboardV2(mes, year)` in `lib/api/dashboard.ts`
- New hook `useDashboardV2` with React Query, `queryKey: ['dashboard-v2', mes, year]`, `staleTime: 2min`
- `DashboardPage` replaced with v2 layout:
  - Month/year dropdown selectors (refetches automatically on change)
  - 4 KPI cards: Ingresos, Egresos, Balance, Tasa de ahorro (with variation % arrows)
  - Central grid: Ultimas transacciones (5) + Egresos por categoria (progress bars)
  - Bottom 3-col grid: Presupuestos (reuses BudgetProgressBar) + Metas activas + Prestamos activos
- New components in `features/dashboard/components/v2/`:
  - `KpiCard.tsx` — reutilizable, soporta variación positiva/negativa (verde/rojo), skeleton integrado
  - `TransaccionItem.tsx` — badge INGRESO/EGRESO, categoria, fecha, monto con signo
  - `EgresoCategoriaBar.tsx` — barra de progreso con porcentaje y monto
  - `MetaProgressItem.tsx` — progress bar con color segun avance, fecha limite opcional
- Reuses `BudgetProgressBar` from `features/presupuestos`

## Tests
- 44 new tests across 5 test files
- 139 total passing (0 failures)
- Coverage: `DashboardPage` (loading/error/success/empty states, selectors), `KpiCard` (variacion +/-/0, skeleton), `TransaccionItem` (ingreso/egreso, categoria null), `EgresoCategoriaBar` (aria, caps), `MetaProgressItem` (progress, fecha, caps)