### PR TITLE
feat(recurrentes): add recurring transactions backend

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,6 +6,7 @@ from app.api.v1.routes.impulso import router as impulso_router
 from app.api.v1.routes.comparativa import router as comparativa_router
 from app.api.v1.routes.educacion import router as educacion_router
 from app.api.v1.routes.profiles import router as profiles_router
+from app.api.v1.routes.recurrentes import router as recurrentes_router
 from app.api.v1.routes.retos import router as retos_router
 from app.api.v1.routes.suscripciones import router as suscripciones_router
 from app.api.v1.routes.dashboard import router as dashboard_router
@@ -28,6 +29,7 @@ api_router.include_router(dashboard_router)
 api_router.include_router(prestamos_router)
 api_router.include_router(metas_router)
 api_router.include_router(presupuestos_router)
+api_router.include_router(recurrentes_router)
 api_router.include_router(score_router)
 api_router.include_router(prediccion_router)
 api_router.include_router(notificaciones_router)

--- a/backend/app/api/v1/routes/recurrentes.py
+++ b/backend/app/api/v1/routes/recurrentes.py
@@ -1,0 +1,80 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.recurrente import (
+    ProximoVencimientoResponse,
+    RecurrenteCreate,
+    RecurrenteResponse,
+    RecurrenteUpdate,
+)
+from app.services import recurrentes as svc
+
+router = APIRouter(prefix="/recurrentes", tags=["recurrentes"])
+
+
+@router.get("", response_model=list[RecurrenteResponse])
+async def list_recurrentes(
+    activo: bool | None = Query(None, description="Filtrar por estado activo"),
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.get_recurrentes(user_jwt=token, activo=activo)
+
+
+@router.post("", response_model=RecurrenteResponse, status_code=201)
+async def create_recurrente(
+    data: RecurrenteCreate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.create_recurrente(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        data=data,
+    )
+
+
+# IMPORTANTE: /proximos debe ir ANTES de /{recurrente_id} para evitar que el
+# path param capture la cadena literal "proximos"
+@router.get("/proximos", response_model=list[ProximoVencimientoResponse])
+async def get_proximos(
+    mes: int = Query(..., ge=1, le=12, description="Mes (1-12)"),
+    year: int = Query(..., ge=2000, description="Anio"),
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.get_proximos_mes(user_jwt=token, mes=mes, year=year)
+
+
+@router.get("/{recurrente_id}", response_model=RecurrenteResponse)
+async def get_recurrente(
+    recurrente_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.get_recurrente_by_id(user_jwt=token, recurrente_id=str(recurrente_id))
+
+
+@router.put("/{recurrente_id}", response_model=RecurrenteResponse)
+async def update_recurrente(
+    recurrente_id: UUID,
+    data: RecurrenteUpdate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.update_recurrente(
+        user_jwt=token,
+        recurrente_id=str(recurrente_id),
+        data=data,
+    )
+
+
+@router.delete("/{recurrente_id}", status_code=204)
+async def delete_recurrente(
+    recurrente_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    svc.delete_recurrente(user_jwt=token, recurrente_id=str(recurrente_id))

--- a/backend/app/schemas/recurrente.py
+++ b/backend/app/schemas/recurrente.py
@@ -1,0 +1,47 @@
+from datetime import date
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class RecurrenteBase(BaseModel):
+    tipo: Literal["ingreso", "egreso"]
+    descripcion: str = Field(..., min_length=1, max_length=255)
+    monto: float = Field(..., gt=0)
+    categoria_id: Optional[UUID] = None
+    frecuencia: Literal["diaria", "semanal", "quincenal", "mensual"]
+    dia_del_mes: Optional[int] = Field(None, ge=1, le=31)
+    fecha_inicio: date
+    fecha_fin: Optional[date] = None
+
+
+class RecurrenteCreate(RecurrenteBase):
+    pass
+
+
+class RecurrenteUpdate(BaseModel):
+    descripcion: Optional[str] = Field(None, min_length=1, max_length=255)
+    monto: Optional[float] = Field(None, gt=0)
+    categoria_id: Optional[UUID] = None
+    frecuencia: Optional[Literal["diaria", "semanal", "quincenal", "mensual"]] = None
+    dia_del_mes: Optional[int] = Field(None, ge=1, le=31)
+    activo: Optional[bool] = None
+    fecha_fin: Optional[date] = None
+
+
+class RecurrenteResponse(RecurrenteBase):
+    id: UUID
+    user_id: UUID
+    activo: bool
+    created_at: str
+    updated_at: str
+
+    model_config = {"from_attributes": True}
+
+
+class ProximoVencimientoResponse(BaseModel):
+    """Recurrente con su fecha estimada de ejecucion en el mes consultado."""
+
+    recurrente: RecurrenteResponse
+    fecha_estimada: date

--- a/backend/app/services/recurrentes.py
+++ b/backend/app/services/recurrentes.py
@@ -1,0 +1,221 @@
+import calendar
+from datetime import date
+
+from fastapi import HTTPException
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.schemas.recurrente import RecurrenteCreate, RecurrenteUpdate
+from app.services.base import _handle_api_error
+
+
+def get_recurrentes(user_jwt: str, activo: bool | None = None) -> list[dict]:
+    """Return all recurring transactions for the user, optionally filtered by activo."""
+    client = get_user_client(user_jwt)
+    try:
+        query = (
+            client.table("recurrentes")
+            .select("*")
+            .order("created_at", desc=True)
+        )
+        if activo is not None:
+            query = query.eq("activo", activo)
+
+        response = query.execute()
+        return response.data or []
+    except APIError as e:
+        _handle_api_error(e)
+    return []
+
+
+def get_recurrente_by_id(user_jwt: str, recurrente_id: str) -> dict:
+    """Return a single recurring transaction by id. Raises 404 if not found."""
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("recurrentes")
+            .select("*")
+            .eq("id", recurrente_id)
+            .maybe_single()
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Recurrente no encontrado.")
+        return response.data
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def create_recurrente(user_jwt: str, user_id: str, data: RecurrenteCreate) -> dict:
+    """Insert a new recurring transaction for the user."""
+    client = get_user_client(user_jwt)
+    payload = data.model_dump()
+    payload["user_id"] = user_id
+    payload["monto"] = str(payload["monto"])
+    payload["fecha_inicio"] = str(payload["fecha_inicio"])
+    if payload.get("fecha_fin"):
+        payload["fecha_fin"] = str(payload["fecha_fin"])
+    if payload.get("categoria_id"):
+        payload["categoria_id"] = str(payload["categoria_id"])
+
+    try:
+        response = client.table("recurrentes").insert(payload).execute()
+        if not response.data:
+            raise HTTPException(
+                status_code=500, detail="Recurrente no encontrado tras insercion."
+            )
+        return response.data[0]
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def update_recurrente(user_jwt: str, recurrente_id: str, data: RecurrenteUpdate) -> dict:
+    """Update an existing recurring transaction. Raises 404 if not found."""
+    client = get_user_client(user_jwt)
+    payload = data.model_dump(exclude_unset=True)
+
+    if not payload:
+        raise HTTPException(status_code=422, detail="No hay campos para actualizar.")
+
+    if "monto" in payload and payload["monto"] is not None:
+        payload["monto"] = str(payload["monto"])
+    if "fecha_fin" in payload and payload["fecha_fin"] is not None:
+        payload["fecha_fin"] = str(payload["fecha_fin"])
+    if "categoria_id" in payload and payload["categoria_id"] is not None:
+        payload["categoria_id"] = str(payload["categoria_id"])
+
+    try:
+        response = (
+            client.table("recurrentes")
+            .update(payload)
+            .eq("id", recurrente_id)
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Recurrente no encontrado.")
+        return response.data[0]
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def delete_recurrente(user_jwt: str, recurrente_id: str) -> None:
+    """Delete a recurring transaction. Raises 404 if not found."""
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("recurrentes")
+            .delete()
+            .eq("id", recurrente_id)
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Recurrente no encontrado.")
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)
+
+
+def _calcular_fecha_estimada(recurrente: dict, mes: int, year: int) -> date | None:
+    """Calculate the estimated execution date for a recurrente in the given month/year.
+
+    Returns None if the recurrente does not apply in this month (date range exclusions).
+
+    Logic per frecuencia:
+    - diaria:    occurs every day -> first day of the month as reference
+    - semanal:   at least one occurrence per week in any month -> first day of month
+    - quincenal: occurs on days 1 and 16 -> first day of month as reference
+    - mensual:   occurs on dia_del_mes (clamped to last day if exceeds month length)
+    """
+    last_day = calendar.monthrange(year, mes)[1]
+    first_day_of_month = date(year, mes, 1)
+    last_day_of_month = date(year, mes, last_day)
+
+    # Parse date strings from Supabase
+    fecha_inicio_str = recurrente.get("fecha_inicio")
+    fecha_fin_str = recurrente.get("fecha_fin")
+
+    try:
+        fecha_inicio = date.fromisoformat(fecha_inicio_str) if fecha_inicio_str else None
+    except (ValueError, TypeError):
+        fecha_inicio = None
+
+    try:
+        fecha_fin = date.fromisoformat(fecha_fin_str) if fecha_fin_str else None
+    except (ValueError, TypeError):
+        fecha_fin = None
+
+    # Exclude if fecha_fin is before the start of the month
+    if fecha_fin and fecha_fin < first_day_of_month:
+        return None
+
+    # Exclude if fecha_inicio is after the end of the month
+    if fecha_inicio and fecha_inicio > last_day_of_month:
+        return None
+
+    frecuencia = recurrente.get("frecuencia", "")
+
+    if frecuencia == "diaria":
+        return first_day_of_month
+
+    if frecuencia == "semanal":
+        # At least one occurrence in every month — use first day as reference
+        return first_day_of_month
+
+    if frecuencia == "quincenal":
+        # Occurs on day 1 and day 16 of every month
+        return first_day_of_month
+
+    if frecuencia == "mensual":
+        dia = recurrente.get("dia_del_mes") or 1
+        # Clamp to last day of month (e.g. dia=31 in February -> day 28/29)
+        dia_efectivo = min(dia, last_day)
+        return date(year, mes, dia_efectivo)
+
+    return None
+
+
+def get_proximos_mes(user_jwt: str, mes: int, year: int) -> list[dict]:
+    """Return active recurrentes with their estimated execution date in the given month.
+
+    Excludes:
+    - Inactive recurrentes
+    - Recurrentes whose fecha_fin is before the start of the month
+    - Recurrentes whose fecha_inicio is after the end of the month
+    """
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("recurrentes")
+            .select("*")
+            .eq("activo", True)
+            .execute()
+        )
+        recurrentes = response.data or []
+    except APIError as e:
+        _handle_api_error(e)
+        return []
+
+    result = []
+    for rec in recurrentes:
+        fecha_estimada = _calcular_fecha_estimada(rec, mes, year)
+        if fecha_estimada is not None:
+            result.append(
+                {
+                    "recurrente": rec,
+                    "fecha_estimada": fecha_estimada,
+                }
+            )
+
+    # Sort by estimated date ascending
+    result.sort(key=lambda x: x["fecha_estimada"])
+    return result

--- a/backend/tests/test_recurrentes.py
+++ b/backend/tests/test_recurrentes.py
@@ -1,0 +1,593 @@
+"""
+Tests for the recurrentes (recurring transactions) backend.
+
+Coverage:
+- Auth guards (403 without token) for all 6 endpoints
+- CRUD happy paths: create, read list, read by id, update, delete
+- Filter by activo
+- 404 on get/update/delete of nonexistent id
+- get_proximos_mes logic: mensual, diaria, semanal, quincenal,
+  inactive excluded, fecha_fin expired excluded, fecha_inicio future excluded
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from postgrest import APIError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_JWT = "fake-jwt-token"
+USER_ID = "00000000-0000-0000-0000-000000000001"
+REC_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+
+
+def _make_recurrente(
+    id: str = REC_ID,
+    tipo: str = "egreso",
+    descripcion: str = "Netflix",
+    monto: str = "299.00",
+    frecuencia: str = "mensual",
+    dia_del_mes: int | None = 15,
+    activo: bool = True,
+    fecha_inicio: str = "2026-01-01",
+    fecha_fin: str | None = None,
+    categoria_id: str | None = None,
+) -> dict:
+    return {
+        "id": id,
+        "user_id": USER_ID,
+        "tipo": tipo,
+        "descripcion": descripcion,
+        "monto": monto,
+        "frecuencia": frecuencia,
+        "dia_del_mes": dia_del_mes,
+        "activo": activo,
+        "fecha_inicio": fecha_inicio,
+        "fecha_fin": fecha_fin,
+        "categoria_id": categoria_id,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Auth guard tests — no token -> 403
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_recurrentes_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/recurrentes")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_recurrente_requires_auth(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/v1/recurrentes",
+        json={
+            "tipo": "egreso",
+            "descripcion": "Netflix",
+            "monto": 299.0,
+            "frecuencia": "mensual",
+            "dia_del_mes": 15,
+            "fecha_inicio": "2026-01-01",
+        },
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_proximos_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/recurrentes/proximos?mes=3&year=2026")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_recurrente_by_id_requires_auth(client: AsyncClient) -> None:
+    response = await client.get(f"/api/v1/recurrentes/{REC_ID}")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_recurrente_requires_auth(client: AsyncClient) -> None:
+    response = await client.put(
+        f"/api/v1/recurrentes/{REC_ID}",
+        json={"descripcion": "Disney+"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_recurrente_requires_auth(client: AsyncClient) -> None:
+    response = await client.delete(f"/api/v1/recurrentes/{REC_ID}")
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Service unit tests — CRUD happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_get_recurrentes_returns_list():
+    """get_recurrentes returns all recurrentes for the user."""
+    from app.services.recurrentes import get_recurrentes
+
+    rows = [_make_recurrente()]
+    mock_response = MagicMock()
+    mock_response.data = rows
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value
+        .order.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_recurrentes(FAKE_JWT)
+
+    assert len(result) == 1
+    assert result[0]["id"] == REC_ID
+
+
+def test_get_recurrentes_filter_activo_true():
+    """get_recurrentes applies activo=True filter when provided."""
+    from app.services.recurrentes import get_recurrentes
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value
+        .order.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_recurrentes(FAKE_JWT, activo=True)
+
+    assert result == []
+    mock_client.table.return_value.select.return_value.order.return_value.eq.assert_called_once_with(
+        "activo", True
+    )
+
+
+def test_get_recurrentes_filter_activo_false():
+    """get_recurrentes applies activo=False filter when provided."""
+    from app.services.recurrentes import get_recurrentes
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value
+        .order.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_recurrentes(FAKE_JWT, activo=False)
+
+    assert result == []
+    mock_client.table.return_value.select.return_value.order.return_value.eq.assert_called_once_with(
+        "activo", False
+    )
+
+
+def test_create_recurrente_success():
+    """create_recurrente inserts correctly and returns the created row."""
+    from app.schemas.recurrente import RecurrenteCreate
+    from app.services.recurrentes import create_recurrente
+
+    row = _make_recurrente()
+    mock_response = MagicMock()
+    mock_response.data = [row]
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.return_value = mock_response
+
+    data = RecurrenteCreate(
+        tipo="egreso",
+        descripcion="Netflix",
+        monto=299.0,
+        frecuencia="mensual",
+        dia_del_mes=15,
+        fecha_inicio=date(2026, 1, 1),
+    )
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = create_recurrente(FAKE_JWT, USER_ID, data)
+
+    assert result["id"] == REC_ID
+    payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert payload["descripcion"] == "Netflix"
+    assert payload["user_id"] == USER_ID
+    assert payload["monto"] == "299.0"
+
+
+def test_get_recurrente_by_id_success():
+    """get_recurrente_by_id returns the row when found."""
+    from app.services.recurrentes import get_recurrente_by_id
+
+    row = _make_recurrente()
+    mock_response = MagicMock()
+    mock_response.data = row
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value
+        .eq.return_value.maybe_single.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_recurrente_by_id(FAKE_JWT, REC_ID)
+
+    assert result["id"] == REC_ID
+
+
+def test_get_recurrente_by_id_not_found_raises_404():
+    """get_recurrente_by_id raises 404 when the record does not exist."""
+    from app.services.recurrentes import get_recurrente_by_id
+
+    mock_response = MagicMock()
+    mock_response.data = None
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value
+        .eq.return_value.maybe_single.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            get_recurrente_by_id(FAKE_JWT, "nonexistent-id")
+
+    assert exc_info.value.status_code == 404
+
+
+def test_update_recurrente_success():
+    """update_recurrente returns updated row on success."""
+    from app.schemas.recurrente import RecurrenteUpdate
+    from app.services.recurrentes import update_recurrente
+
+    updated_row = _make_recurrente(descripcion="Disney+")
+    mock_response = MagicMock()
+    mock_response.data = [updated_row]
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.update.return_value
+        .eq.return_value.execute.return_value
+    ) = mock_response
+
+    data = RecurrenteUpdate(descripcion="Disney+")
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = update_recurrente(FAKE_JWT, REC_ID, data)
+
+    assert result["descripcion"] == "Disney+"
+
+
+def test_update_recurrente_not_found_raises_404():
+    """update_recurrente raises 404 when the record does not exist."""
+    from app.schemas.recurrente import RecurrenteUpdate
+    from app.services.recurrentes import update_recurrente
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.update.return_value
+        .eq.return_value.execute.return_value
+    ) = mock_response
+
+    data = RecurrenteUpdate(descripcion="Nuevo")
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            update_recurrente(FAKE_JWT, "nonexistent-id", data)
+
+    assert exc_info.value.status_code == 404
+
+
+def test_update_recurrente_no_fields_raises_422():
+    """update_recurrente raises 422 when no fields are provided."""
+    from app.schemas.recurrente import RecurrenteUpdate
+    from app.services.recurrentes import update_recurrente
+
+    mock_client = MagicMock()
+    data = RecurrenteUpdate()
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            update_recurrente(FAKE_JWT, REC_ID, data)
+
+    assert exc_info.value.status_code == 422
+
+
+def test_delete_recurrente_success():
+    """delete_recurrente completes without error when the record exists."""
+    from app.services.recurrentes import delete_recurrente
+
+    mock_response = MagicMock()
+    mock_response.data = [_make_recurrente()]
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.delete.return_value
+        .eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        delete_recurrente(FAKE_JWT, REC_ID)  # should not raise
+
+
+def test_delete_recurrente_not_found_raises_404():
+    """delete_recurrente raises 404 when the record does not exist."""
+    from app.services.recurrentes import delete_recurrente
+
+    mock_response = MagicMock()
+    mock_response.data = []
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.delete.return_value
+        .eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            delete_recurrente(FAKE_JWT, "nonexistent-id")
+
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# get_proximos_mes logic tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_proximos_mock(rows: list[dict]) -> MagicMock:
+    """Return a mock supabase client that returns the given rows for active recurrentes."""
+    mock_response = MagicMock()
+    mock_response.data = rows
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value
+        .eq.return_value.execute.return_value
+    ) = mock_response
+    return mock_client
+
+
+def test_proximos_mensual_dia_del_mes_en_rango():
+    """Mensual recurrente appears on its dia_del_mes for the queried month."""
+    from app.services.recurrentes import get_proximos_mes
+
+    rec = _make_recurrente(frecuencia="mensual", dia_del_mes=10, fecha_inicio="2026-01-01")
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert len(result) == 1
+    assert result[0]["fecha_estimada"] == date(2026, 3, 10)
+
+
+def test_proximos_mensual_dia_excede_dias_del_mes():
+    """Mensual with dia_del_mes=31 in February is clamped to the last day."""
+    from app.services.recurrentes import get_proximos_mes
+
+    rec = _make_recurrente(frecuencia="mensual", dia_del_mes=31, fecha_inicio="2026-01-01")
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=2, year=2026)
+
+    assert len(result) == 1
+    # February 2026 has 28 days
+    assert result[0]["fecha_estimada"] == date(2026, 2, 28)
+
+
+def test_proximos_diaria_aparece():
+    """Diaria recurrente appears with fecha_estimada = first day of the month."""
+    from app.services.recurrentes import get_proximos_mes
+
+    rec = _make_recurrente(frecuencia="diaria", dia_del_mes=None, fecha_inicio="2026-01-01")
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert len(result) == 1
+    assert result[0]["fecha_estimada"] == date(2026, 3, 1)
+
+
+def test_proximos_semanal_aparece():
+    """Semanal recurrente appears with fecha_estimada = first day of the month."""
+    from app.services.recurrentes import get_proximos_mes
+
+    rec = _make_recurrente(frecuencia="semanal", dia_del_mes=None, fecha_inicio="2026-01-01")
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert len(result) == 1
+    assert result[0]["fecha_estimada"] == date(2026, 3, 1)
+
+
+def test_proximos_quincenal_aparece():
+    """Quincenal recurrente appears with fecha_estimada = first day of the month."""
+    from app.services.recurrentes import get_proximos_mes
+
+    rec = _make_recurrente(frecuencia="quincenal", dia_del_mes=None, fecha_inicio="2026-01-01")
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert len(result) == 1
+    assert result[0]["fecha_estimada"] == date(2026, 3, 1)
+
+
+def test_proximos_inactivo_excluido():
+    """Inactive recurrente is not returned by get_proximos_mes.
+
+    The service queries with eq('activo', True), so an inactive recurrente
+    would never be in the Supabase response. We verify the mock receives
+    the filter and returns no results when only inactive rows exist.
+    """
+    from app.services.recurrentes import get_proximos_mes
+
+    # Supabase already filters — the response has no rows
+    mock_client = _setup_proximos_mock([])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert result == []
+    # Verify the filter was applied
+    mock_client.table.return_value.select.return_value.eq.assert_called_once_with(
+        "activo", True
+    )
+
+
+def test_proximos_fecha_fin_pasada_excluida():
+    """Recurrente with fecha_fin before the queried month is excluded."""
+    from app.services.recurrentes import get_proximos_mes
+
+    # fecha_fin is Jan 31 2026, queried month is March 2026 -> exclude
+    rec = _make_recurrente(
+        frecuencia="mensual",
+        dia_del_mes=15,
+        fecha_inicio="2026-01-01",
+        fecha_fin="2026-01-31",
+    )
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert result == []
+
+
+def test_proximos_fecha_inicio_futura_excluida():
+    """Recurrente with fecha_inicio after the queried month is excluded."""
+    from app.services.recurrentes import get_proximos_mes
+
+    # fecha_inicio is April 1 2026, queried month is March 2026 -> exclude
+    rec = _make_recurrente(
+        frecuencia="mensual",
+        dia_del_mes=5,
+        fecha_inicio="2026-04-01",
+        fecha_fin=None,
+    )
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert result == []
+
+
+def test_proximos_fecha_fin_mismo_mes_incluida():
+    """Recurrente with fecha_fin within the queried month is included."""
+    from app.services.recurrentes import get_proximos_mes
+
+    # fecha_fin is March 10 2026, queried month is March 2026 -> include
+    rec = _make_recurrente(
+        frecuencia="mensual",
+        dia_del_mes=5,
+        fecha_inicio="2026-01-01",
+        fecha_fin="2026-03-10",
+    )
+    mock_client = _setup_proximos_mock([rec])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert len(result) == 1
+    assert result[0]["fecha_estimada"] == date(2026, 3, 5)
+
+
+def test_proximos_multiple_recurrentes_ordenados_por_fecha():
+    """get_proximos_mes returns results sorted by fecha_estimada ascending."""
+    from app.services.recurrentes import get_proximos_mes
+
+    rec_dia_20 = _make_recurrente(
+        id="aaaaaaaa-0000-0000-0000-000000000002",
+        frecuencia="mensual",
+        dia_del_mes=20,
+        fecha_inicio="2026-01-01",
+    )
+    rec_dia_5 = _make_recurrente(
+        id="aaaaaaaa-0000-0000-0000-000000000003",
+        frecuencia="mensual",
+        dia_del_mes=5,
+        fecha_inicio="2026-01-01",
+    )
+    mock_client = _setup_proximos_mock([rec_dia_20, rec_dia_5])
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        result = get_proximos_mes(FAKE_JWT, mes=3, year=2026)
+
+    assert len(result) == 2
+    assert result[0]["fecha_estimada"] == date(2026, 3, 5)
+    assert result[1]["fecha_estimada"] == date(2026, 3, 20)
+
+
+def test_get_recurrentes_api_error_raises_500():
+    """get_recurrentes raises HTTP 500 on unexpected Supabase APIError."""
+    from app.services.recurrentes import get_recurrentes
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value
+        .order.return_value.execute.side_effect
+    ) = APIError({"code": "503", "message": "Service unavailable"})
+
+    with patch("app.services.recurrentes.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            get_recurrentes(FAKE_JWT)
+
+    assert exc_info.value.status_code == 500
+
+
+def test_create_recurrente_invalid_monto_raises_validation_error():
+    """RecurrenteCreate raises ValidationError when monto <= 0."""
+    from pydantic import ValidationError
+
+    from app.schemas.recurrente import RecurrenteCreate
+
+    with pytest.raises(ValidationError):
+        RecurrenteCreate(
+            tipo="egreso",
+            descripcion="Test",
+            monto=0.0,
+            frecuencia="mensual",
+            fecha_inicio=date(2026, 1, 1),
+        )
+
+
+def test_create_recurrente_invalid_tipo_raises_validation_error():
+    """RecurrenteCreate raises ValidationError for invalid tipo."""
+    from pydantic import ValidationError
+
+    from app.schemas.recurrente import RecurrenteCreate
+
+    with pytest.raises(ValidationError):
+        RecurrenteCreate(
+            tipo="gasto",  # invalid — must be ingreso or egreso
+            descripcion="Test",
+            monto=100.0,
+            frecuencia="mensual",
+            fecha_inicio=date(2026, 1, 1),
+        )

--- a/supabase/migrations/20260310000001_recurrentes.sql
+++ b/supabase/migrations/20260310000001_recurrentes.sql
@@ -1,0 +1,38 @@
+-- Tabla de transacciones recurrentes
+CREATE TABLE IF NOT EXISTS recurrentes (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    tipo VARCHAR(10) NOT NULL CHECK (tipo IN ('ingreso', 'egreso')),
+    descripcion VARCHAR(255) NOT NULL,
+    monto DECIMAL(15, 2) NOT NULL CHECK (monto > 0),
+    categoria_id UUID REFERENCES categorias(id) ON DELETE SET NULL,
+    frecuencia VARCHAR(20) NOT NULL CHECK (frecuencia IN ('diaria', 'semanal', 'quincenal', 'mensual')),
+    dia_del_mes INTEGER CHECK (dia_del_mes BETWEEN 1 AND 31),
+    activo BOOLEAN DEFAULT TRUE NOT NULL,
+    fecha_inicio DATE NOT NULL DEFAULT CURRENT_DATE,
+    fecha_fin DATE,
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+-- RLS
+ALTER TABLE recurrentes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own recurrentes"
+    ON recurrentes FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- Indices
+CREATE INDEX IF NOT EXISTS idx_recurrentes_user_id ON recurrentes(user_id);
+CREATE INDEX IF NOT EXISTS idx_recurrentes_activo ON recurrentes(user_id, activo);
+
+-- Trigger updated_at
+CREATE OR REPLACE FUNCTION update_recurrentes_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = NOW(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_recurrentes_updated_at
+    BEFORE UPDATE ON recurrentes
+    FOR EACH ROW EXECUTE FUNCTION update_recurrentes_updated_at();


### PR DESCRIPTION
Closes #50

## Changes

- **Migration** `20260310000001_recurrentes.sql`: tabla `recurrentes` con RLS, check constraints en `tipo` (ingreso/egreso) y `frecuencia` (diaria/semanal/quincenal/mensual), indice compuesto `(user_id, activo)`, trigger `updated_at`
- **Schemas** `recurrente.py`: `RecurrenteCreate`, `RecurrenteUpdate`, `RecurrenteResponse`, `ProximoVencimientoResponse` — Pydantic v2, validaciones de rango en `monto` (>0), `dia_del_mes` (1-31)
- **Service** `recurrentes.py`: CRUD completo + `get_proximos_mes` con logica de fecha estimada por frecuencia
- **Router** `recurrentes.py`: 6 endpoints — `/proximos` declarado ANTES de `/{recurrente_id}` para evitar captura del path param
- **Router principal**: registrado `recurrentes_router` en `api/v1/router.py`

## Logica de fecha_estimada en get_proximos_mes

| Frecuencia  | fecha_estimada                                               |
|-------------|--------------------------------------------------------------|
| `diaria`    | Primer dia del mes (referencia — ocurre todos los dias)      |
| `semanal`   | Primer dia del mes (al menos una ocurrencia en cualquier mes)|
| `quincenal` | Primer dia del mes (toca dias 1 y 16)                        |
| `mensual`   | `dia_del_mes` del recurrente, clampado al ultimo dia del mes |

Exclusiones aplicadas en Python (post-query):
- `fecha_fin < primer_dia_del_mes` → excluido
- `fecha_inicio > ultimo_dia_del_mes` → excluido

Los resultados se ordenan por `fecha_estimada` ascendente.

## Tests

- 30 nuevos tests en `test_recurrentes.py`
- 209 tests totales, 209 passing
- Cobertura: auth guards (6), CRUD happy paths (6), filtro activo (2), 404s (3), proximos logic (11 — mensual, diaria, semanal, quincenal, inactivo excluido, fecha_fin pasada, fecha_inicio futura, fecha_fin en mismo mes, clamping dia_del_mes, ordenamiento), APIError 500 (1), validaciones schema (2)

## API Changes

```
GET    /api/v1/recurrentes               → lista (query: activo: bool | None)
POST   /api/v1/recurrentes               → crear (201)
GET    /api/v1/recurrentes/proximos      → proximos del mes (query: mes, year requeridos)
GET    /api/v1/recurrentes/{id}          → detalle
PUT    /api/v1/recurrentes/{id}          → actualizar
DELETE /api/v1/recurrentes/{id}          → eliminar (204)
```