### PR TITLE
feat(ui): redesign all app pages with modern design system

### DIFF
--- a/frontend/src/components/transacciones/TransaccionRow.tsx
+++ b/frontend/src/components/transacciones/TransaccionRow.tsx
@@ -30,10 +30,10 @@ export function TransaccionRow({
           aria-hidden="true"
         />
         <div className="min-w-0">
-          <p className="text-sm font-medium text-gray-900 truncate">
+          <p className="text-sm font-medium text-[var(--text-primary)] truncate">
             {transaccion.descripcion ?? categoriaNombre}
           </p>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-[var(--text-muted)]">
             {categoriaNombre} &middot; {formatDate(transaccion.fecha)}
           </p>
         </div>

--- a/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/DashboardPage.test.tsx
@@ -130,18 +130,18 @@ describe('DashboardPage', () => {
 
   it('renders ingresos KPI with data', () => {
     render(<DashboardPage />)
-    expect(screen.getByText('Ingresos del mes')).toBeInTheDocument()
+    expect(screen.getByText('Ingresos')).toBeInTheDocument()
     expect(screen.getAllByText(/50,000/).length).toBeGreaterThan(0)
   })
 
   it('renders egresos KPI with data', () => {
     render(<DashboardPage />)
-    expect(screen.getByText('Egresos del mes')).toBeInTheDocument()
+    expect(screen.getByText('Egresos')).toBeInTheDocument()
   })
 
   it('renders balance KPI with data', () => {
     render(<DashboardPage />)
-    expect(screen.getByText('Balance del mes')).toBeInTheDocument()
+    expect(screen.getByText('Balance')).toBeInTheDocument()
   })
 
   it('renders tasa de ahorro KPI', () => {
@@ -164,7 +164,7 @@ describe('DashboardPage', () => {
 
   it('renders presupuestos section', () => {
     render(<DashboardPage />)
-    expect(screen.getByText('Presupuestos')).toBeInTheDocument()
+    expect(screen.getByText('Presupuestos activos')).toBeInTheDocument()
   })
 
   it('renders metas activas section', () => {
@@ -193,13 +193,13 @@ describe('DashboardPage', () => {
   it('shows empty state for transactions when list is empty', () => {
     setupMock({ data: { ...mockData, ultimas_transacciones: [] } })
     render(<DashboardPage />)
-    expect(screen.getAllByText(/no hay datos para este periodo/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/sin transacciones este mes/i).length).toBeGreaterThan(0)
   })
 
   it('shows empty state for metas when list is empty', () => {
     setupMock({ data: { ...mockData, metas_activas: [] } })
     render(<DashboardPage />)
-    expect(screen.getAllByText(/no hay datos para este periodo/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/sin datos/i).length).toBeGreaterThan(0)
   })
 
   it('changes mes when selector changes', () => {

--- a/frontend/src/features/dashboard/components/v2/KpiCard.tsx
+++ b/frontend/src/features/dashboard/components/v2/KpiCard.tsx
@@ -14,7 +14,7 @@ interface KpiCardProps {
 
 function VariationBadge({ pct }: { pct: number }): JSX.Element {
   if (pct === 0) {
-    return <span className="text-xs text-gray-400 font-medium">—</span>
+    return <span className="text-xs text-[var(--text-muted)] font-medium">—</span>
   }
 
   const isPositive = pct > 0
@@ -59,14 +59,14 @@ export function KpiCard({
   variationPct,
   icon,
   iconBg,
-  valueColorClass = 'text-gray-900',
+  valueColorClass = 'text-[var(--text-primary)]',
   subtitle,
 }: KpiCardProps): JSX.Element {
   return (
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium text-gray-500">
+          <CardTitle className="text-sm font-medium text-[var(--text-muted)]">
             {title}
           </CardTitle>
           <div
@@ -87,7 +87,7 @@ export function KpiCard({
             <VariationBadge pct={variationPct} />
           )}
           {subtitle && (
-            <p className="text-xs text-gray-400">{subtitle}</p>
+            <p className="text-xs text-[var(--text-muted)]">{subtitle}</p>
           )}
         </div>
       </CardContent>

--- a/frontend/src/features/metas/__tests__/MetasPage.test.tsx
+++ b/frontend/src/features/metas/__tests__/MetasPage.test.tsx
@@ -144,7 +144,7 @@ describe('MetasPage', () => {
     setupMocks({ metasData: [] })
     render(<MetasPage />)
     expect(
-      screen.getByText(/no tienes metas de ahorro todavia/i)
+      screen.getByText(/sin metas de ahorro/i)
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/features/metas/components/MetaCard.tsx
+++ b/frontend/src/features/metas/components/MetaCard.tsx
@@ -54,12 +54,12 @@ export function MetaCard({ meta, onClick }: MetaCardProps): JSX.Element {
             aria-hidden="true"
           />
           <div className="min-w-0">
-            <p className="text-sm font-semibold text-gray-900 truncate">
+            <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
               {meta.icono ? `${meta.icono} ` : ''}
               {meta.nombre}
             </p>
             {meta.descripcion && (
-              <p className="text-xs text-gray-400 truncate mt-0.5">
+              <p className="text-xs text-[var(--text-muted)] truncate mt-0.5">
                 {meta.descripcion}
               </p>
             )}
@@ -86,17 +86,17 @@ export function MetaCard({ meta, onClick }: MetaCardProps): JSX.Element {
       {/* Montos */}
       <div className="flex items-end justify-between mb-2">
         <div>
-          <p className="text-xs text-gray-400">Ahorrado</p>
+          <p className="text-xs text-[var(--text-muted)]">Ahorrado</p>
           <p
-            className="text-lg font-bold money"
+            className="text-lg font-bold font-mono"
             style={{ color: colorMeta }}
           >
             {formatMoney(meta.monto_actual)}
           </p>
         </div>
         <div className="text-right">
-          <p className="text-xs text-gray-400">Objetivo</p>
-          <p className="text-sm font-semibold text-gray-700">
+          <p className="text-xs text-[var(--text-muted)]">Objetivo</p>
+          <p className="text-sm font-semibold text-[var(--text-primary)]">
             {formatMoney(meta.monto_objetivo)}
           </p>
         </div>
@@ -108,15 +108,15 @@ export function MetaCard({ meta, onClick }: MetaCardProps): JSX.Element {
         color={colorMeta}
         aria-label={`${Math.round(porcentaje)}% de la meta ${meta.nombre}`}
       />
-      <p className="text-xs text-gray-400 mt-1">
+      <p className="text-xs text-[var(--text-muted)] mt-1">
         {Math.round(porcentaje)}% completado
       </p>
 
       {/* Fecha objetivo */}
       {meta.fecha_objetivo && (
-        <p className="text-xs text-gray-400 mt-2">
+        <p className="text-xs text-[var(--text-muted)] mt-2">
           Objetivo:{' '}
-          <span className="text-gray-600">{formatDate(meta.fecha_objetivo)}</span>
+          <span className="text-[var(--text-primary)]">{formatDate(meta.fecha_objetivo)}</span>
         </p>
       )}
     </button>

--- a/frontend/src/features/metas/components/MetasResumenCards.tsx
+++ b/frontend/src/features/metas/components/MetasResumenCards.tsx
@@ -45,30 +45,28 @@ export function MetasResumenCards(): JSX.Element {
 
       {/* Total ahorrado */}
       <div className="finza-card border-l-4 border-prosperity-green">
-        <p className="text-sm font-medium text-gray-500 mb-1">
+        <p className="text-sm font-medium text-[var(--text-muted)] mb-1">
           Total ahorrado
         </p>
         <p
-          className="text-2xl font-bold money"
-          style={{ color: '#00B050' }}
+          className="text-2xl font-bold font-mono text-prosperity-green"
           aria-label={`Total ahorrado ${formatMoney(resumen.total_ahorrado)}`}
         >
           {formatMoney(resumen.total_ahorrado)}
         </p>
-        <p className="text-xs text-gray-400 mt-1">En metas activas</p>
+        <p className="text-xs text-[var(--text-muted)] mt-1">En metas activas</p>
       </div>
 
       {/* Metas activas */}
       <div className="finza-card border-l-4 border-finza-blue">
-        <p className="text-sm font-medium text-gray-500 mb-1">Metas activas</p>
+        <p className="text-sm font-medium text-[var(--text-muted)] mb-1">Metas activas</p>
         <p
-          className="text-2xl font-bold"
-          style={{ color: '#366092' }}
+          className="text-2xl font-bold text-finza-blue"
           aria-label={`${resumen.metas_activas} metas activas`}
         >
           {resumen.metas_activas}
         </p>
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-[var(--text-muted)] mt-1">
           {resumen.metas_completadas} completada
           {resumen.metas_completadas !== 1 ? 's' : ''}
         </p>
@@ -76,17 +74,16 @@ export function MetasResumenCards(): JSX.Element {
 
       {/* Cumplimiento promedio */}
       <div className="finza-card border-l-4 border-golden-flow">
-        <p className="text-sm font-medium text-gray-500 mb-1">
+        <p className="text-sm font-medium text-[var(--text-muted)] mb-1">
           Cumplimiento promedio
         </p>
         <p
-          className="text-2xl font-bold"
-          style={{ color: '#FFC000' }}
+          className="text-2xl font-bold text-golden-flow"
           aria-label={`${Math.round(resumen.porcentaje_promedio_cumplimiento)}% cumplimiento promedio`}
         >
           {Math.round(resumen.porcentaje_promedio_cumplimiento)}%
         </p>
-        <p className="text-xs text-gray-400 mt-1">Sobre todas las metas</p>
+        <p className="text-xs text-[var(--text-muted)] mt-1">Sobre todas las metas</p>
       </div>
     </div>
   )

--- a/frontend/src/features/prestamos/__tests__/PrestamoRow.test.tsx
+++ b/frontend/src/features/prestamos/__tests__/PrestamoRow.test.tsx
@@ -93,6 +93,7 @@ describe('PrestamoRow', () => {
 
   it('renders monto original and pendiente', () => {
     render(<PrestamoRow prestamo={mockPrestamoActivo} onClick={vi.fn()} />)
-    expect(screen.getByText(/de/i)).toBeInTheDocument()
+    // Verify the "de RD$X" pattern for monto_original
+    expect(screen.getAllByText(/de/i).length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/features/prestamos/components/PrestamoResumenCards.tsx
+++ b/frontend/src/features/prestamos/components/PrestamoResumenCards.tsx
@@ -40,15 +40,14 @@ export function PrestamoResumenCards(): JSX.Element {
 
       {/* Me deben */}
       <div className="finza-card border-l-4 border-prosperity-green">
-        <p className="text-sm font-medium text-gray-500 mb-1">Me deben</p>
+        <p className="text-sm font-medium text-[var(--text-muted)] mb-1">Me deben</p>
         <p
-          className="text-2xl font-bold money"
-          style={{ color: '#00B050' }}
+          className="text-2xl font-bold font-mono text-prosperity-green"
           aria-label={`Me deben ${formatMoney(resumen.total_me_deben)}`}
         >
           {formatMoney(resumen.total_me_deben)}
         </p>
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-[var(--text-muted)] mt-1">
           {resumen.cantidad_activos} activo{resumen.cantidad_activos !== 1 ? 's' : ''}
           {resumen.cantidad_vencidos > 0 && (
             <span className="text-alert-red ml-2">
@@ -60,15 +59,14 @@ export function PrestamoResumenCards(): JSX.Element {
 
       {/* Yo debo */}
       <div className="finza-card border-l-4 border-alert-red">
-        <p className="text-sm font-medium text-gray-500 mb-1">Yo debo</p>
+        <p className="text-sm font-medium text-[var(--text-muted)] mb-1">Yo debo</p>
         <p
-          className="text-2xl font-bold money"
-          style={{ color: '#FF0000' }}
+          className="text-2xl font-bold font-mono text-alert-red"
           aria-label={`Yo debo ${formatMoney(resumen.total_yo_debo)}`}
         >
           {formatMoney(resumen.total_yo_debo)}
         </p>
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-[var(--text-muted)] mt-1">
           Total pendiente
         </p>
       </div>

--- a/frontend/src/features/presupuestos/__tests__/PresupuestosPage.test.tsx
+++ b/frontend/src/features/presupuestos/__tests__/PresupuestosPage.test.tsx
@@ -169,7 +169,7 @@ describe('PresupuestosPage', () => {
     setupMocks({ estadoData: [] })
     render(<PresupuestosPage />)
     expect(
-      screen.getByText(/no hay presupuestos asignados para este mes/i)
+      screen.getByText(/sin presupuestos/i)
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/features/presupuestos/components/PresupuestoCard.tsx
+++ b/frontend/src/features/presupuestos/components/PresupuestoCard.tsx
@@ -23,7 +23,7 @@ export function PresupuestoCard({
     >
       {/* Header: nombre + badges de alerta */}
       <div className="flex items-start justify-between gap-2 mb-3">
-        <p className="text-sm font-semibold text-gray-900 truncate">
+        <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
           {estado.categoria_nombre}
         </p>
         <div className="flex items-center gap-1 flex-shrink-0">
@@ -43,22 +43,22 @@ export function PresupuestoCard({
       {/* Montos */}
       <div className="flex items-end justify-between mb-2">
         <div>
-          <p className="text-xs text-gray-400">Gastado</p>
+          <p className="text-xs text-[var(--text-muted)]">Gastado</p>
           <p
-            className={`text-lg font-bold money ${
+            className={`text-lg font-bold font-mono ${
               excedido
                 ? 'text-alert-red'
                 : estado.alerta
                   ? 'text-golden-flow'
-                  : 'text-gray-900'
+                  : 'text-[var(--text-primary)]'
             }`}
           >
             {formatMoney(estado.gasto_actual)}
           </p>
         </div>
         <div className="text-right">
-          <p className="text-xs text-gray-400">Limite</p>
-          <p className="text-sm font-semibold text-gray-600">
+          <p className="text-xs text-[var(--text-muted)]">Limite</p>
+          <p className="text-sm font-semibold text-[var(--text-muted)]">
             {formatMoney(estado.monto_limite)}
           </p>
         </div>
@@ -69,7 +69,7 @@ export function PresupuestoCard({
         porcentaje={estado.porcentaje_usado}
         aria-label={`${Math.round(estado.porcentaje_usado)}% del presupuesto de ${estado.categoria_nombre} usado`}
       />
-      <p className="text-xs text-gray-400 mt-1">
+      <p className="text-xs text-[var(--text-muted)] mt-1">
         {Math.round(estado.porcentaje_usado)}% usado
       </p>
     </button>

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -13,10 +13,19 @@ export function formatMoney(amount: number, currency: string = 'DOP'): string {
   }).format(amount)}`
 }
 
+export function formatCurrency(amount: number, currency = 'DOP'): string {
+  return formatMoney(amount, currency)
+}
+
 export function formatDate(date: string | Date): string {
   return new Intl.DateTimeFormat('es-DO', {
     day: '2-digit',
-    month: '2-digit',
+    month: 'short',
     year: 'numeric',
   }).format(new Date(date))
 }
+
+export const MESES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+]

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   TrendingUp,
   TrendingDown,
@@ -7,20 +8,17 @@ import {
   AlertCircle,
   CreditCard,
   CalendarClock,
+  BarChart3,
 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useDashboardV2 } from '@/hooks/useDashboardV2'
 import { KpiCard } from '@/features/dashboard/components/v2/KpiCard'
 import { TransaccionItem } from '@/features/dashboard/components/v2/TransaccionItem'
 import { EgresoCategoriaBar } from '@/features/dashboard/components/v2/EgresoCategoriaBar'
 import { MetaProgressItem } from '@/features/dashboard/components/v2/MetaProgressItem'
 import { BudgetProgressBar } from '@/features/presupuestos/components/BudgetProgressBar'
-import { formatDate, formatMoney } from '@/lib/utils'
-
-const MONTH_NAMES = [
-  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
-  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
-]
+import { formatDate, formatMoney, MESES } from '@/lib/utils'
 
 function getInitialPeriod(): { mes: number; year: number } {
   const now = new Date()
@@ -32,6 +30,7 @@ function buildYearOptions(currentYear: number): number[] {
 }
 
 export function DashboardPage(): JSX.Element {
+  const { t } = useTranslation()
   const now = new Date()
   const currentYear = now.getFullYear()
 
@@ -41,14 +40,19 @@ export function DashboardPage(): JSX.Element {
   const { data, isLoading, isError, error } = useDashboardV2({ mes, year })
 
   const yearOptions = buildYearOptions(currentYear)
+  const monthName = MESES[mes - 1]
 
   return (
-    <div>
+    <div className="animate-fade-in">
       {/* Page header */}
       <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="text-gray-500 text-sm mt-1">Resumen financiero del mes</p>
+          <h1 className="text-2xl font-bold text-[var(--text-primary)]">
+            {t('dashboard.title')}
+          </h1>
+          <p className="text-[var(--text-muted)] text-sm mt-1">
+            {t('dashboard.thisMonth')}: {monthName} {year}
+          </p>
         </div>
 
         {/* Month / Year selector */}
@@ -60,9 +64,9 @@ export function DashboardPage(): JSX.Element {
               aria-label="Mes"
               value={mes}
               onChange={(e) => setMes(Number(e.target.value))}
-              className="block w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-finza-blue focus:outline-none focus:ring-1 focus:ring-finza-blue"
+              className="finza-input text-sm"
             >
-              {MONTH_NAMES.map((name, idx) => (
+              {MESES.map((name, idx) => (
                 <option key={name} value={idx + 1}>
                   {name}
                 </option>
@@ -77,7 +81,7 @@ export function DashboardPage(): JSX.Element {
               aria-label="Ano"
               value={year}
               onChange={(e) => setYear(Number(e.target.value))}
-              className="block w-full rounded-lg border border-border bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-finza-blue focus:outline-none focus:ring-1 focus:ring-finza-blue"
+              className="finza-input text-sm"
             >
               {yearOptions.map((y) => (
                 <option key={y} value={y}>
@@ -92,7 +96,7 @@ export function DashboardPage(): JSX.Element {
       {/* Error state */}
       {isError && (
         <div
-          className="flex items-center gap-3 p-4 mb-6 bg-red-50 border border-red-200 rounded-lg text-red-700"
+          className="flex items-center gap-3 p-4 mb-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 rounded-lg text-red-700 dark:text-red-400"
           role="alert"
         >
           <AlertCircle size={18} className="flex-shrink-0" />
@@ -106,33 +110,33 @@ export function DashboardPage(): JSX.Element {
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
         {isLoading ? (
           <>
-            <KpiCard.Skeleton />
-            <KpiCard.Skeleton />
-            <KpiCard.Skeleton />
-            <KpiCard.Skeleton />
+            <Skeleton className="h-32 rounded-card" />
+            <Skeleton className="h-32 rounded-card" />
+            <Skeleton className="h-32 rounded-card" />
+            <Skeleton className="h-32 rounded-card" />
           </>
         ) : (
           <>
             <KpiCard
-              title="Ingresos del mes"
+              title={t('dashboard.income')}
               value={formatMoney(data?.resumen_financiero.ingresos_mes ?? 0)}
               variationPct={data?.resumen_financiero.variacion_ingresos_pct ?? 0}
               icon={<TrendingUp size={18} style={{ color: '#00B050' }} />}
               iconBg="#00B05020"
               valueColorClass="text-prosperity-green"
-              subtitle="vs. mes anterior"
+              subtitle={t('dashboard.vsLastMonth')}
             />
             <KpiCard
-              title="Egresos del mes"
+              title={t('dashboard.expenses')}
               value={formatMoney(data?.resumen_financiero.egresos_mes ?? 0)}
               variationPct={data?.resumen_financiero.variacion_egresos_pct ?? 0}
               icon={<TrendingDown size={18} style={{ color: '#FF0000' }} />}
               iconBg="#FF000020"
               valueColorClass="text-alert-red"
-              subtitle="vs. mes anterior"
+              subtitle={t('dashboard.vsLastMonth')}
             />
             <KpiCard
-              title="Balance del mes"
+              title={t('dashboard.balance')}
               value={formatMoney(Math.abs(data?.resumen_financiero.balance_mes ?? 0))}
               icon={<Wallet size={18} style={{ color: '#366092' }} />}
               iconBg="#36609220"
@@ -144,7 +148,7 @@ export function DashboardPage(): JSX.Element {
               subtitle="Ingresos - Egresos"
             />
             <KpiCard
-              title="Tasa de ahorro"
+              title={t('dashboard.savingsRate')}
               value={`${(data?.resumen_financiero.tasa_ahorro ?? 0).toFixed(1)}%`}
               icon={<Target size={18} style={{ color: '#FFC000' }} />}
               iconBg="#FFC00020"
@@ -160,22 +164,20 @@ export function DashboardPage(): JSX.Element {
         {/* Recent transactions */}
         <Card>
           <CardHeader>
-            <CardTitle>Ultimas transacciones</CardTitle>
+            <CardTitle>{t('dashboard.recentTransactions')}</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
-              <div aria-label="Cargando transacciones">
+              <div aria-label="Cargando transacciones" className="space-y-3">
                 {[...Array(5)].map((_, i) => (
-                  <div key={i} className="py-3 border-b border-border last:border-0">
-                    <div className="h-4 w-48 bg-flow-light rounded animate-pulse mb-1" />
-                    <div className="h-3 w-32 bg-flow-light rounded animate-pulse" />
-                  </div>
+                  <Skeleton key={i} className="h-10 w-full" />
                 ))}
               </div>
             ) : (data?.ultimas_transacciones ?? []).length === 0 ? (
-              <p className="text-sm text-gray-400 text-center py-8">
-                No hay datos para este periodo
-              </p>
+              <div className="text-center py-12 text-[var(--text-muted)]">
+                <BarChart3 size={48} className="mx-auto mb-3 opacity-30" />
+                <p className="text-sm">{t('dashboard.noTransactions')}</p>
+              </div>
             ) : (
               <div>
                 {(data?.ultimas_transacciones ?? []).slice(0, 5).map((tx, idx) => (
@@ -189,22 +191,23 @@ export function DashboardPage(): JSX.Element {
         {/* Egresos por categoria */}
         <Card>
           <CardHeader>
-            <CardTitle>Egresos por categoria</CardTitle>
+            <CardTitle>{t('dashboard.expensesByCategory')}</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="space-y-4">
                 {[...Array(4)].map((_, i) => (
                   <div key={i} className="space-y-1">
-                    <div className="h-4 w-32 bg-flow-light rounded animate-pulse" />
-                    <div className="h-2 w-full bg-flow-light rounded animate-pulse" />
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-2 w-full" />
                   </div>
                 ))}
               </div>
             ) : (data?.egresos_por_categoria ?? []).length === 0 ? (
-              <p className="text-sm text-gray-400 text-center py-8">
-                No hay datos para este periodo
-              </p>
+              <div className="text-center py-12 text-[var(--text-muted)]">
+                <BarChart3 size={48} className="mx-auto mb-3 opacity-30" />
+                <p className="text-sm">{t('dashboard.noTransactions')}</p>
+              </div>
             ) : (
               <div className="space-y-4">
                 {(data?.egresos_por_categoria ?? []).map((item) => (
@@ -221,21 +224,21 @@ export function DashboardPage(): JSX.Element {
         {/* Presupuestos */}
         <Card>
           <CardHeader>
-            <CardTitle>Presupuestos</CardTitle>
+            <CardTitle>{t('dashboard.activeBudgets')}</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="space-y-4">
                 {[...Array(3)].map((_, i) => (
                   <div key={i} className="space-y-1">
-                    <div className="h-4 w-28 bg-flow-light rounded animate-pulse" />
-                    <div className="h-2.5 w-full bg-flow-light rounded animate-pulse" />
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-2 w-full" />
                   </div>
                 ))}
               </div>
             ) : (data?.presupuestos_estado ?? []).length === 0 ? (
-              <p className="text-sm text-gray-400 text-center py-6">
-                No hay datos para este periodo
+              <p className="text-sm text-[var(--text-muted)] text-center py-6">
+                {t('common.noData')}
               </p>
             ) : (
               <div className="space-y-4">
@@ -246,12 +249,12 @@ export function DashboardPage(): JSX.Element {
                         className={
                           pres.alerta
                             ? 'font-semibold text-alert-red'
-                            : 'font-medium text-gray-700'
+                            : 'font-medium text-[var(--text-primary)]'
                         }
                       >
                         {pres.categoria}
                       </span>
-                      <span className="text-xs text-gray-400">
+                      <span className="text-xs text-[var(--text-muted)]">
                         {pres.porcentaje_usado.toFixed(0)}%
                       </span>
                     </div>
@@ -259,7 +262,7 @@ export function DashboardPage(): JSX.Element {
                       porcentaje={pres.porcentaje_usado}
                       aria-label={`Presupuesto ${pres.categoria}: ${pres.porcentaje_usado.toFixed(0)}% usado`}
                     />
-                    <p className="text-xs text-gray-400">
+                    <p className="text-xs text-[var(--text-muted)]">
                       {formatMoney(pres.gasto_actual)} / {formatMoney(pres.monto_presupuestado)}
                     </p>
                   </div>
@@ -272,21 +275,21 @@ export function DashboardPage(): JSX.Element {
         {/* Metas activas */}
         <Card>
           <CardHeader>
-            <CardTitle>Metas activas</CardTitle>
+            <CardTitle>{t('dashboard.activeGoals')}</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="space-y-4">
                 {[...Array(3)].map((_, i) => (
                   <div key={i} className="space-y-1">
-                    <div className="h-4 w-28 bg-flow-light rounded animate-pulse" />
-                    <div className="h-1.5 w-full bg-flow-light rounded animate-pulse" />
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-1.5 w-full" />
                   </div>
                 ))}
               </div>
             ) : (data?.metas_activas ?? []).length === 0 ? (
-              <p className="text-sm text-gray-400 text-center py-6">
-                No hay datos para este periodo
+              <p className="text-sm text-[var(--text-muted)] text-center py-6">
+                {t('common.noData')}
               </p>
             ) : (
               <div className="space-y-4">
@@ -301,29 +304,29 @@ export function DashboardPage(): JSX.Element {
         {/* Prestamos activos */}
         <Card>
           <CardHeader>
-            <CardTitle>Prestamos activos</CardTitle>
+            <CardTitle>{t('dashboard.activeLoans')}</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="space-y-3">
-                <div className="h-8 w-40 bg-flow-light rounded animate-pulse" />
-                <div className="h-4 w-24 bg-flow-light rounded animate-pulse" />
-                <div className="h-4 w-32 bg-flow-light rounded animate-pulse" />
+                <Skeleton className="h-8 w-40" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-32" />
               </div>
             ) : (data?.prestamos_activos.count ?? 0) === 0 ? (
               <div className="flex flex-col items-center justify-center py-6 text-center">
-                <CreditCard size={32} className="text-gray-300 mb-2" aria-hidden="true" />
-                <p className="text-sm text-gray-400">Sin prestamos activos</p>
+                <CreditCard size={32} className="text-[var(--text-muted)] opacity-40 mb-2" aria-hidden="true" />
+                <p className="text-sm text-[var(--text-muted)]">Sin prestamos activos</p>
               </div>
             ) : (
               <div className="space-y-3">
                 <div>
-                  <p className="text-xs text-gray-400 mb-0.5">Deuda total</p>
+                  <p className="text-xs text-[var(--text-muted)] mb-0.5">Deuda total</p>
                   <p className="text-2xl font-bold font-mono text-alert-red">
                     {formatMoney(data?.prestamos_activos.total_deuda ?? 0)}
                   </p>
                 </div>
-                <div className="flex items-center gap-2 text-sm text-gray-600">
+                <div className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
                   <CreditCard size={14} className="text-finza-blue" aria-hidden="true" />
                   <span>
                     {data?.prestamos_activos.count ?? 0}{' '}
@@ -332,7 +335,7 @@ export function DashboardPage(): JSX.Element {
                   </span>
                 </div>
                 {data?.prestamos_activos.proximo_vencimiento && (
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                  <div className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
                     <CalendarClock size={14} className="text-golden-flow" aria-hidden="true" />
                     <span>
                       Proximo vencimiento:{' '}

--- a/frontend/src/pages/EgresosPage.tsx
+++ b/frontend/src/pages/EgresosPage.tsx
@@ -1,32 +1,83 @@
-import { useState } from 'react'
-import { Plus } from 'lucide-react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Plus, TrendingDown, Pencil, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import { TransaccionModal } from '@/components/transacciones/TransaccionModal'
-import { TransaccionesList } from '@/components/transacciones/TransaccionesList'
-import { MoneyDisplay } from '@/components/shared/MoneyDisplay'
 import { useEgresos, useCreateEgreso, useDeleteEgreso } from '@/hooks/useEgresos'
 import { useCategorias } from '@/hooks/useCategorias'
+import { formatCurrency, formatDate, MESES, cn } from '@/lib/utils'
 import type { IngresoFormData, EgresoFormData } from '@/components/transacciones/TransaccionForm'
 import type { EgresoResponse } from '@/types/transacciones'
 
+function getDefaultPeriod(): { mes: number; year: number } {
+  const now = new Date()
+  return { mes: now.getMonth() + 1, year: now.getFullYear() }
+}
+
+function buildYearOptions(currentYear: number): number[] {
+  return [currentYear - 1, currentYear, currentYear + 1]
+}
+
 export function EgresosPage(): JSX.Element {
+  const { t } = useTranslation()
+  const defaults = getDefaultPeriod()
+  const currentYear = defaults.year
+
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const { data, isLoading } = useEgresos({ page: 1, page_size: 50 })
+  const [mes, setMes] = useState<number>(defaults.mes)
+  const [year, setYear] = useState<number>(defaults.year)
+  const [search, setSearch] = useState('')
+
+  const { data, isLoading } = useEgresos({ page: 1, page_size: 200 })
   const { data: categorias = [] } = useCategorias('egreso')
   const createEgreso = useCreateEgreso()
   const deleteEgreso = useDeleteEgreso()
 
-  const totalMes = data?.items.reduce((sum, e) => sum + parseFloat(e.monto), 0) ?? 0
+  const yearOptions = buildYearOptions(currentYear)
+  const categoriasMap = useMemo(
+    () => Object.fromEntries(categorias.map((c) => [c.id, c.nombre])),
+    [categorias]
+  )
+
+  const filteredItems = useMemo(() => {
+    const items = data?.items ?? []
+    const searchLower = search.toLowerCase()
+    return items.filter((item) => {
+      const fecha = new Date(item.fecha)
+      const matchesMes = fecha.getMonth() + 1 === mes && fecha.getFullYear() === year
+      const matchesSearch = searchLower === '' ||
+        (item.descripcion?.toLowerCase().includes(searchLower) ?? false) ||
+        (categoriasMap[item.categoria_id]?.toLowerCase().includes(searchLower) ?? false)
+      return matchesMes && matchesSearch
+    })
+  }, [data?.items, mes, year, search, categoriasMap])
+
+  const totalMes = useMemo(
+    () => filteredItems.reduce((sum, e) => sum + parseFloat(e.monto), 0),
+    [filteredItems]
+  )
 
   const handleCreate = async (formData: IngresoFormData | EgresoFormData): Promise<void> => {
-    await createEgreso.mutateAsync(formData)
-    setIsModalOpen(false)
+    try {
+      await createEgreso.mutateAsync(formData)
+      setIsModalOpen(false)
+      toast.success(t('egresos.created'))
+    } catch {
+      toast.error(t('common.error'))
+    }
   }
 
   const handleDelete = async (id: string): Promise<void> => {
     if (window.confirm('Eliminar este egreso?')) {
-      await deleteEgreso.mutateAsync(id)
+      try {
+        await deleteEgreso.mutateAsync(id)
+        toast.success(t('egresos.deleted'))
+      } catch {
+        toast.error(t('common.error'))
+      }
     }
   }
 
@@ -35,36 +86,183 @@ export function EgresosPage(): JSX.Element {
   }
 
   return (
-    <div>
+    <div className="animate-fade-in">
+      {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Egresos</h1>
-          <p className="text-gray-500 text-sm mt-1 flex items-center gap-1">
-            Total:{' '}
-            <MoneyDisplay amount={totalMes} type="egreso" size="sm" />
+          <h1 className="text-2xl font-bold text-[var(--text-primary)]">{t('egresos.title')}</h1>
+          <p className="text-[var(--text-muted)] text-sm mt-1">
+            {MESES[mes - 1]} {year}
           </p>
         </div>
-        <Button onClick={() => setIsModalOpen(true)} variant="default">
-          <Plus size={18} className="mr-2" />
-          Nuevo egreso
+        <Button onClick={() => setIsModalOpen(true)} variant="default" size="md">
+          <Plus size={16} />
+          {t('egresos.newEgreso')}
         </Button>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Historial de egresos</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <TransaccionesList
-            transacciones={data?.items ?? []}
-            tipo="egreso"
-            categorias={categorias}
-            isLoading={isLoading}
-            onEdit={(t) => handleEdit(t as EgresoResponse)}
-            onDelete={handleDelete}
-          />
-        </CardContent>
-      </Card>
+      {/* Stats cards */}
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <div className="finza-card">
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-7 w-32" />
+            </div>
+          ) : (
+            <>
+              <p className="text-sm text-[var(--text-muted)]">{t('egresos.totalMonth')}</p>
+              <p className="text-2xl font-bold text-[var(--text-primary)] mt-1 font-mono">
+                {formatCurrency(totalMes)}
+              </p>
+            </>
+          )}
+        </div>
+        <div className="finza-card">
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-7 w-16" />
+            </div>
+          ) : (
+            <>
+              <p className="text-sm text-[var(--text-muted)]">{t('egresos.count')}</p>
+              <p className="text-2xl font-bold text-[var(--text-primary)] mt-1">
+                {filteredItems.length}
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 mb-4">
+        <div>
+          <label htmlFor="egresos-mes" className="sr-only">{t('common.month')}</label>
+          <select
+            id="egresos-mes"
+            aria-label={t('common.month')}
+            className="finza-input text-sm"
+            value={mes}
+            onChange={(e) => setMes(Number(e.target.value))}
+          >
+            {MESES.map((nombre, idx) => (
+              <option key={idx + 1} value={idx + 1}>{nombre}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="egresos-year" className="sr-only">{t('common.year')}</label>
+          <select
+            id="egresos-year"
+            aria-label={t('common.year')}
+            className="finza-input text-sm"
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+          >
+            {yearOptions.map((y) => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+        </div>
+        <input
+          type="text"
+          placeholder={t('common.search')}
+          className="finza-input text-sm flex-1 min-w-[200px]"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label={t('common.search')}
+        />
+      </div>
+
+      {/* Table / States */}
+      {isLoading ? (
+        <div className="finza-card overflow-hidden p-4 space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : filteredItems.length === 0 ? (
+        <div className="text-center py-16">
+          <TrendingDown size={48} className="mx-auto mb-3 text-[var(--text-muted)] opacity-40" />
+          <p className="font-medium text-[var(--text-primary)]">{t('egresos.noEgresos')}</p>
+          <p className="text-sm text-[var(--text-muted)] mb-4">{t('egresos.noEgresosDesc')}</p>
+          <Button onClick={() => setIsModalOpen(true)} size="md">
+            <Plus size={16} />
+            {t('egresos.newEgreso')}
+          </Button>
+        </div>
+      ) : (
+        <div className="finza-card overflow-hidden p-0">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-surface-raised">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                  {t('common.description')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider hidden sm:table-cell">
+                  {t('common.category')}
+                </th>
+                <th className="text-right px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                  {t('common.amount')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider hidden md:table-cell">
+                  {t('common.date')}
+                </th>
+                <th className="px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                  {t('common.actions')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredItems.map((item, i) => (
+                <tr
+                  key={item.id}
+                  className={cn(
+                    'border-b border-border last:border-0 hover:bg-surface-raised transition-colors',
+                    i % 2 !== 0 ? 'bg-surface-raised/50' : ''
+                  )}
+                >
+                  <td className="px-4 py-3 text-sm text-[var(--text-primary)]">
+                    {item.descripcion ?? categoriasMap[item.categoria_id] ?? '—'}
+                  </td>
+                  <td className="px-4 py-3 hidden sm:table-cell">
+                    <Badge variant="neutral">
+                      {categoriasMap[item.categoria_id] ?? '—'}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono font-semibold text-alert-red">
+                    -{formatCurrency(parseFloat(item.monto), item.moneda)}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-[var(--text-muted)] hidden md:table-cell">
+                    {formatDate(item.fecha)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => handleEdit(item)}
+                        className="p-1.5 rounded text-[var(--text-muted)] hover:text-finza-blue hover:bg-surface-raised transition-colors"
+                        aria-label="Editar"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(item.id)}
+                        className="p-1.5 rounded text-[var(--text-muted)] hover:text-alert-red hover:bg-surface-raised transition-colors"
+                        aria-label="Eliminar"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       <TransaccionModal
         tipo="egreso"

--- a/frontend/src/pages/IngresosPage.tsx
+++ b/frontend/src/pages/IngresosPage.tsx
@@ -1,32 +1,83 @@
-import { useState } from 'react'
-import { Plus } from 'lucide-react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Plus, TrendingUp, Pencil, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import { TransaccionModal } from '@/components/transacciones/TransaccionModal'
-import { TransaccionesList } from '@/components/transacciones/TransaccionesList'
-import { MoneyDisplay } from '@/components/shared/MoneyDisplay'
 import { useIngresos, useCreateIngreso, useDeleteIngreso } from '@/hooks/useIngresos'
 import { useCategorias } from '@/hooks/useCategorias'
+import { formatCurrency, formatDate, MESES, cn } from '@/lib/utils'
 import type { IngresoFormData, EgresoFormData } from '@/components/transacciones/TransaccionForm'
 import type { IngresoResponse } from '@/types/transacciones'
 
+function getDefaultPeriod(): { mes: number; year: number } {
+  const now = new Date()
+  return { mes: now.getMonth() + 1, year: now.getFullYear() }
+}
+
+function buildYearOptions(currentYear: number): number[] {
+  return [currentYear - 1, currentYear, currentYear + 1]
+}
+
 export function IngresosPage(): JSX.Element {
+  const { t } = useTranslation()
+  const defaults = getDefaultPeriod()
+  const currentYear = defaults.year
+
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const { data, isLoading } = useIngresos({ page: 1, page_size: 50 })
+  const [mes, setMes] = useState<number>(defaults.mes)
+  const [year, setYear] = useState<number>(defaults.year)
+  const [search, setSearch] = useState('')
+
+  const { data, isLoading } = useIngresos({ page: 1, page_size: 200 })
   const { data: categorias = [] } = useCategorias('ingreso')
   const createIngreso = useCreateIngreso()
   const deleteIngreso = useDeleteIngreso()
 
-  const totalMes = data?.items.reduce((sum, i) => sum + parseFloat(i.monto), 0) ?? 0
+  const yearOptions = buildYearOptions(currentYear)
+  const categoriasMap = useMemo(
+    () => Object.fromEntries(categorias.map((c) => [c.id, c.nombre])),
+    [categorias]
+  )
+
+  const filteredItems = useMemo(() => {
+    const items = data?.items ?? []
+    const searchLower = search.toLowerCase()
+    return items.filter((item) => {
+      const fecha = new Date(item.fecha)
+      const matchesMes = fecha.getMonth() + 1 === mes && fecha.getFullYear() === year
+      const matchesSearch = searchLower === '' ||
+        (item.descripcion?.toLowerCase().includes(searchLower) ?? false) ||
+        (categoriasMap[item.categoria_id]?.toLowerCase().includes(searchLower) ?? false)
+      return matchesMes && matchesSearch
+    })
+  }, [data?.items, mes, year, search, categoriasMap])
+
+  const totalMes = useMemo(
+    () => filteredItems.reduce((sum, i) => sum + parseFloat(i.monto), 0),
+    [filteredItems]
+  )
 
   const handleCreate = async (formData: IngresoFormData | EgresoFormData): Promise<void> => {
-    await createIngreso.mutateAsync(formData)
-    setIsModalOpen(false)
+    try {
+      await createIngreso.mutateAsync(formData)
+      setIsModalOpen(false)
+      toast.success(t('ingresos.created'))
+    } catch {
+      toast.error(t('common.error'))
+    }
   }
 
   const handleDelete = async (id: string): Promise<void> => {
     if (window.confirm('Eliminar este ingreso?')) {
-      await deleteIngreso.mutateAsync(id)
+      try {
+        await deleteIngreso.mutateAsync(id)
+        toast.success(t('ingresos.deleted'))
+      } catch {
+        toast.error(t('common.error'))
+      }
     }
   }
 
@@ -35,36 +86,183 @@ export function IngresosPage(): JSX.Element {
   }
 
   return (
-    <div>
+    <div className="animate-fade-in">
+      {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Ingresos</h1>
-          <p className="text-gray-500 text-sm mt-1 flex items-center gap-1">
-            Total:{' '}
-            <MoneyDisplay amount={totalMes} type="ingreso" size="sm" />
+          <h1 className="text-2xl font-bold text-[var(--text-primary)]">{t('ingresos.title')}</h1>
+          <p className="text-[var(--text-muted)] text-sm mt-1">
+            {MESES[mes - 1]} {year}
           </p>
         </div>
-        <Button onClick={() => setIsModalOpen(true)} variant="success">
-          <Plus size={18} className="mr-2" />
-          Nuevo ingreso
+        <Button onClick={() => setIsModalOpen(true)} variant="success" size="md">
+          <Plus size={16} />
+          {t('ingresos.newIngreso')}
         </Button>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Historial de ingresos</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <TransaccionesList
-            transacciones={data?.items ?? []}
-            tipo="ingreso"
-            categorias={categorias}
-            isLoading={isLoading}
-            onEdit={(t) => handleEdit(t as IngresoResponse)}
-            onDelete={handleDelete}
-          />
-        </CardContent>
-      </Card>
+      {/* Stats cards */}
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <div className="finza-card">
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-7 w-32" />
+            </div>
+          ) : (
+            <>
+              <p className="text-sm text-[var(--text-muted)]">{t('ingresos.totalMonth')}</p>
+              <p className="text-2xl font-bold text-[var(--text-primary)] mt-1 font-mono">
+                {formatCurrency(totalMes)}
+              </p>
+            </>
+          )}
+        </div>
+        <div className="finza-card">
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-7 w-16" />
+            </div>
+          ) : (
+            <>
+              <p className="text-sm text-[var(--text-muted)]">{t('ingresos.count')}</p>
+              <p className="text-2xl font-bold text-[var(--text-primary)] mt-1">
+                {filteredItems.length}
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 mb-4">
+        <div>
+          <label htmlFor="ingresos-mes" className="sr-only">{t('common.month')}</label>
+          <select
+            id="ingresos-mes"
+            aria-label={t('common.month')}
+            className="finza-input text-sm"
+            value={mes}
+            onChange={(e) => setMes(Number(e.target.value))}
+          >
+            {MESES.map((nombre, idx) => (
+              <option key={idx + 1} value={idx + 1}>{nombre}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="ingresos-year" className="sr-only">{t('common.year')}</label>
+          <select
+            id="ingresos-year"
+            aria-label={t('common.year')}
+            className="finza-input text-sm"
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+          >
+            {yearOptions.map((y) => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+        </div>
+        <input
+          type="text"
+          placeholder={t('common.search')}
+          className="finza-input text-sm flex-1 min-w-[200px]"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label={t('common.search')}
+        />
+      </div>
+
+      {/* Table / States */}
+      {isLoading ? (
+        <div className="finza-card overflow-hidden p-4 space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : filteredItems.length === 0 ? (
+        <div className="text-center py-16">
+          <TrendingUp size={48} className="mx-auto mb-3 text-[var(--text-muted)] opacity-40" />
+          <p className="font-medium text-[var(--text-primary)]">{t('ingresos.noIngresos')}</p>
+          <p className="text-sm text-[var(--text-muted)] mb-4">{t('ingresos.noIngresosDesc')}</p>
+          <Button onClick={() => setIsModalOpen(true)} size="md">
+            <Plus size={16} />
+            {t('ingresos.newIngreso')}
+          </Button>
+        </div>
+      ) : (
+        <div className="finza-card overflow-hidden p-0">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-border bg-surface-raised">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                  {t('common.description')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider hidden sm:table-cell">
+                  {t('common.category')}
+                </th>
+                <th className="text-right px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                  {t('common.amount')}
+                </th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider hidden md:table-cell">
+                  {t('common.date')}
+                </th>
+                <th className="px-4 py-3 text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                  {t('common.actions')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredItems.map((item, i) => (
+                <tr
+                  key={item.id}
+                  className={cn(
+                    'border-b border-border last:border-0 hover:bg-surface-raised transition-colors',
+                    i % 2 !== 0 ? 'bg-surface-raised/50' : ''
+                  )}
+                >
+                  <td className="px-4 py-3 text-sm text-[var(--text-primary)]">
+                    {item.descripcion ?? categoriasMap[item.categoria_id] ?? '—'}
+                  </td>
+                  <td className="px-4 py-3 hidden sm:table-cell">
+                    <Badge variant="neutral">
+                      {categoriasMap[item.categoria_id] ?? '—'}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono font-semibold text-prosperity-green">
+                    +{formatCurrency(parseFloat(item.monto), item.moneda)}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-[var(--text-muted)] hidden md:table-cell">
+                    {formatDate(item.fecha)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => handleEdit(item)}
+                        className="p-1.5 rounded text-[var(--text-muted)] hover:text-finza-blue hover:bg-surface-raised transition-colors"
+                        aria-label="Editar"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(item.id)}
+                        className="p-1.5 rounded text-[var(--text-muted)] hover:text-alert-red hover:bg-surface-raised transition-colors"
+                        aria-label="Eliminar"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       <TransaccionModal
         tipo="ingreso"

--- a/frontend/src/pages/MetasPage.tsx
+++ b/frontend/src/pages/MetasPage.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Plus, Target } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { MetasResumenCards } from '@/features/metas/components/MetasResumenCards'
 import { MetaCard } from '@/features/metas/components/MetaCard'
 import { MetaModal } from '@/features/metas/components/MetaModal'
@@ -14,36 +17,42 @@ function SkeletonCard(): JSX.Element {
     <div className="finza-card animate-pulse">
       <div className="flex items-start justify-between gap-3 mb-3">
         <div className="flex items-center gap-2">
-          <div className="w-3 h-3 rounded-full bg-gray-200" />
-          <div className="h-4 w-32 bg-gray-200 rounded" />
+          <Skeleton className="w-3 h-3 rounded-full" />
+          <Skeleton className="h-4 w-32" />
         </div>
-        <div className="h-5 w-16 bg-gray-200 rounded-full" />
+        <Skeleton className="h-5 w-16 rounded-full" />
       </div>
       <div className="flex justify-between mb-2">
-        <div className="h-6 w-24 bg-gray-200 rounded" />
-        <div className="h-4 w-20 bg-gray-200 rounded" />
+        <Skeleton className="h-6 w-24" />
+        <Skeleton className="h-4 w-20" />
       </div>
-      <div className="h-2 w-full bg-gray-200 rounded-full" />
-      <div className="h-3 w-16 bg-gray-200 rounded mt-1" />
+      <Skeleton className="h-2 w-full rounded-full" />
+      <Skeleton className="h-3 w-16 mt-1" />
     </div>
   )
 }
 
-function EmptyState(): JSX.Element {
+function EmptyState({ onNew }: { onNew: () => void }): JSX.Element {
+  const { t } = useTranslation()
   return (
     <div className="col-span-2 flex flex-col items-center justify-center py-16 text-center">
-      <Target size={48} className="text-gray-300 mb-4" aria-hidden="true" />
-      <p className="text-sm font-medium text-gray-500">
-        No tienes metas de ahorro todavia
+      <Target size={48} className="text-[var(--text-muted)] opacity-40 mb-4" aria-hidden="true" />
+      <p className="text-sm font-medium text-[var(--text-primary)]">
+        {t('metas.noMetas')}
       </p>
-      <p className="text-xs text-gray-400 mt-1">
-        Crea tu primera meta con el boton &ldquo;Nueva Meta&rdquo;
+      <p className="text-xs text-[var(--text-muted)] mt-1 mb-4">
+        {t('metas.noMetasDesc')}
       </p>
+      <Button onClick={onNew} size="md">
+        <Plus size={16} />
+        {t('metas.newMeta')}
+      </Button>
     </div>
   )
 }
 
 export function MetasPage(): JSX.Element {
+  const { t } = useTranslation()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [metaSeleccionada, setMetaSeleccionada] = useState<MetaAhorro | null>(null)
   const [metaEditando, setMetaEditando] = useState<MetaAhorro | null>(null)
@@ -55,38 +64,53 @@ export function MetasPage(): JSX.Element {
   const deleteMeta = useDeleteMeta()
 
   const handleCreate = async (data: MetaFormData): Promise<void> => {
-    await createMeta.mutateAsync({
-      nombre: data.nombre,
-      monto_objetivo: data.monto_objetivo,
-      fecha_inicio: data.fecha_inicio,
-      descripcion: data.descripcion || undefined,
-      fecha_objetivo: data.fecha_objetivo || undefined,
-      color: data.color || undefined,
-      icono: data.icono || undefined,
-    })
-    setIsModalOpen(false)
+    try {
+      await createMeta.mutateAsync({
+        nombre: data.nombre,
+        monto_objetivo: data.monto_objetivo,
+        fecha_inicio: data.fecha_inicio,
+        descripcion: data.descripcion || undefined,
+        fecha_objetivo: data.fecha_objetivo || undefined,
+        color: data.color || undefined,
+        icono: data.icono || undefined,
+      })
+      setIsModalOpen(false)
+      toast.success(t('metas.created'))
+    } catch {
+      toast.error(t('common.error'))
+    }
   }
 
   const handleEdit = async (data: MetaFormData): Promise<void> => {
     if (!metaEditando) return
-    await updateMeta.mutateAsync({
-      id: metaEditando.id,
-      nombre: data.nombre,
-      monto_objetivo: data.monto_objetivo,
-      fecha_inicio: data.fecha_inicio,
-      descripcion: data.descripcion || undefined,
-      fecha_objetivo: data.fecha_objetivo || undefined,
-      color: data.color || undefined,
-      icono: data.icono || undefined,
-    })
-    setMetaEditando(null)
+    try {
+      await updateMeta.mutateAsync({
+        id: metaEditando.id,
+        nombre: data.nombre,
+        monto_objetivo: data.monto_objetivo,
+        fecha_inicio: data.fecha_inicio,
+        descripcion: data.descripcion || undefined,
+        fecha_objetivo: data.fecha_objetivo || undefined,
+        color: data.color || undefined,
+        icono: data.icono || undefined,
+      })
+      setMetaEditando(null)
+      toast.success(t('metas.updated'))
+    } catch {
+      toast.error(t('common.error'))
+    }
   }
 
   const handleDelete = async (id: string): Promise<void> => {
     if (window.confirm('Eliminar esta meta de ahorro?')) {
-      await deleteMeta.mutateAsync(id)
-      setDetailId(null)
-      setMetaSeleccionada(null)
+      try {
+        await deleteMeta.mutateAsync(id)
+        setDetailId(null)
+        setMetaSeleccionada(null)
+        toast.success(t('metas.deleted'))
+      } catch {
+        toast.error(t('common.error'))
+      }
     }
   }
 
@@ -107,18 +131,18 @@ export function MetasPage(): JSX.Element {
   }
 
   return (
-    <div>
+    <div className="animate-fade-in">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Metas de ahorro</h1>
-          <p className="text-gray-500 text-sm mt-1">
+          <h1 className="text-2xl font-bold text-[var(--text-primary)]">{t('metas.title')}</h1>
+          <p className="text-[var(--text-muted)] text-sm mt-1">
             Gestiona tus objetivos financieros
           </p>
         </div>
-        <Button onClick={() => setIsModalOpen(true)} variant="default">
-          <Plus size={18} className="mr-2" />
-          Nueva Meta
+        <Button onClick={() => setIsModalOpen(true)} variant="default" size="md">
+          <Plus size={16} />
+          {t('metas.newMeta')}
         </Button>
       </div>
 
@@ -129,7 +153,7 @@ export function MetasPage(): JSX.Element {
 
       {/* Error state */}
       {isError && (
-        <p className="text-sm text-gray-400 text-center py-4 mb-4">
+        <p className="text-sm text-[var(--text-muted)] text-center py-4 mb-4">
           El servidor no esta disponible. Las metas se mostraran cuando el
           backend responda.
         </p>
@@ -137,7 +161,6 @@ export function MetasPage(): JSX.Element {
 
       {/* Grid de metas */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {/* Loading state */}
         {isLoading && !isError && (
           <>
             <SkeletonCard />
@@ -147,10 +170,10 @@ export function MetasPage(): JSX.Element {
           </>
         )}
 
-        {/* Empty state */}
-        {!isLoading && !isError && metas.length === 0 && <EmptyState />}
+        {!isLoading && !isError && metas.length === 0 && (
+          <EmptyState onNew={() => setIsModalOpen(true)} />
+        )}
 
-        {/* Lista de metas */}
         {!isLoading &&
           metas.map((meta) => (
             <MetaCard key={meta.id} meta={meta} onClick={handleOpenDetail} />

--- a/frontend/src/pages/PrestamosPage.tsx
+++ b/frontend/src/pages/PrestamosPage.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Plus, HandCoins } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/lib/utils'
 import { PrestamoResumenCards } from '@/features/prestamos/components/PrestamoResumenCards'
 import { PrestamoRow } from '@/features/prestamos/components/PrestamoRow'
@@ -23,16 +25,16 @@ function SkeletonRow(): JSX.Element {
     <div className="px-4 py-4 border-b border-border animate-pulse">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3 flex-1">
-          <div className="w-2 h-2 rounded-full bg-gray-200 mt-1.5 flex-shrink-0" />
+          <Skeleton className="w-2 h-2 rounded-full mt-1.5 flex-shrink-0" />
           <div className="flex-1 space-y-2">
-            <div className="h-4 w-32 bg-gray-200 rounded" />
-            <div className="h-2 w-full bg-gray-200 rounded" />
-            <div className="h-3 w-16 bg-gray-200 rounded" />
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-2 w-full" />
+            <Skeleton className="h-3 w-16" />
           </div>
         </div>
         <div className="space-y-1 text-right">
-          <div className="h-4 w-24 bg-gray-200 rounded" />
-          <div className="h-3 w-16 bg-gray-200 rounded" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-16" />
         </div>
       </div>
     </div>
@@ -40,22 +42,24 @@ function SkeletonRow(): JSX.Element {
 }
 
 function EmptyState({ tipo }: { tipo: TipoPrestamo }): JSX.Element {
+  const { t } = useTranslation()
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
-      <HandCoins size={40} className="text-gray-300 mb-3" aria-hidden="true" />
-      <p className="text-sm font-medium text-gray-500">
+      <HandCoins size={40} className="text-[var(--text-muted)] opacity-40 mb-3" aria-hidden="true" />
+      <p className="text-sm font-medium text-[var(--text-primary)]">
         {tipo === 'me_deben'
           ? 'No hay prestamos donde te deban'
           : 'No hay prestamos donde debas'}
       </p>
-      <p className="text-xs text-gray-400 mt-1">
-        Registra un nuevo prestamo con el boton &ldquo;+ Nuevo&rdquo;
+      <p className="text-xs text-[var(--text-muted)] mt-1">
+        {t('prestamos.noPrestamosDesc')}
       </p>
     </div>
   )
 }
 
 export function PrestamosPage(): JSX.Element {
+  const { t } = useTranslation()
   const [tabActiva, setTabActiva] = useState<TabActiva>('me_deben')
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [prestamoSeleccionado, setPrestamoSeleccionado] = useState<Prestamo | null>(null)
@@ -67,42 +71,56 @@ export function PrestamosPage(): JSX.Element {
   const updatePrestamo = useUpdatePrestamo()
   const deletePrestamo = useDeletePrestamo()
 
-  // Solo mostrar activos y vencidos en la lista principal — pagados con opacidad
   const prestamosOrdenados = [...prestamos].sort((a, b) => {
     const prioridad = { vencido: 0, activo: 1, pagado: 2 }
     return prioridad[a.estado] - prioridad[b.estado]
   })
 
   const handleCreate = async (data: PrestamoFormData): Promise<void> => {
-    await createPrestamo.mutateAsync({
-      ...data,
-      fecha_vencimiento: data.fecha_vencimiento || undefined,
-      descripcion: data.descripcion || undefined,
-      notas: data.notas || undefined,
-    })
-    setIsModalOpen(false)
+    try {
+      await createPrestamo.mutateAsync({
+        ...data,
+        fecha_vencimiento: data.fecha_vencimiento || undefined,
+        descripcion: data.descripcion || undefined,
+        notas: data.notas || undefined,
+      })
+      setIsModalOpen(false)
+      toast.success(t('prestamos.created'))
+    } catch {
+      toast.error(t('common.error'))
+    }
   }
 
   const handleEdit = async (data: PrestamoFormData): Promise<void> => {
     if (!prestamoEditando) return
-    await updatePrestamo.mutateAsync({
-      id: prestamoEditando.id,
-      persona: data.persona,
-      monto_original: data.monto_original,
-      moneda: data.moneda,
-      fecha_prestamo: data.fecha_prestamo,
-      fecha_vencimiento: data.fecha_vencimiento || undefined,
-      descripcion: data.descripcion || undefined,
-      notas: data.notas || undefined,
-    })
-    setPrestamoEditando(null)
+    try {
+      await updatePrestamo.mutateAsync({
+        id: prestamoEditando.id,
+        persona: data.persona,
+        monto_original: data.monto_original,
+        moneda: data.moneda,
+        fecha_prestamo: data.fecha_prestamo,
+        fecha_vencimiento: data.fecha_vencimiento || undefined,
+        descripcion: data.descripcion || undefined,
+        notas: data.notas || undefined,
+      })
+      setPrestamoEditando(null)
+      toast.success(t('prestamos.updated'))
+    } catch {
+      toast.error(t('common.error'))
+    }
   }
 
   const handleDelete = async (id: string): Promise<void> => {
     if (window.confirm('Eliminar este prestamo?')) {
-      await deletePrestamo.mutateAsync(id)
-      setDetailId(null)
-      setPrestamoSeleccionado(null)
+      try {
+        await deletePrestamo.mutateAsync(id)
+        setDetailId(null)
+        setPrestamoSeleccionado(null)
+        toast.success(t('prestamos.deleted'))
+      } catch {
+        toast.error(t('common.error'))
+      }
     }
   }
 
@@ -128,16 +146,16 @@ export function PrestamosPage(): JSX.Element {
   ]
 
   return (
-    <div>
+    <div className="animate-fade-in">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Prestamos</h1>
-          <p className="text-gray-500 text-sm mt-1">Gestiona tus prestamos y cobros</p>
+          <h1 className="text-2xl font-bold text-[var(--text-primary)]">{t('prestamos.title')}</h1>
+          <p className="text-[var(--text-muted)] text-sm mt-1">Gestiona tus prestamos y cobros</p>
         </div>
-        <Button onClick={() => setIsModalOpen(true)} variant="default">
-          <Plus size={18} className="mr-2" />
-          Nuevo
+        <Button onClick={() => setIsModalOpen(true)} variant="default" size="md">
+          <Plus size={16} />
+          {t('common.new')}
         </Button>
       </div>
 
@@ -147,34 +165,32 @@ export function PrestamosPage(): JSX.Element {
       </div>
 
       {/* Tabs + lista */}
-      <Card>
-        <CardHeader>
-          {/* Tabs */}
-          <div className="flex gap-1 border-b border-border -mb-4 pb-0">
-            {tabs.map((tab) => (
-              <button
-                key={tab.value}
-                type="button"
-                role="tab"
-                aria-selected={tabActiva === tab.value}
-                onClick={() => setTabActiva(tab.value)}
-                className={cn(
-                  'px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px',
-                  tabActiva === tab.value
-                    ? 'border-finza-blue text-finza-blue'
-                    : 'border-transparent text-gray-500 hover:text-gray-700'
-                )}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-        </CardHeader>
+      <div className="finza-card p-0 overflow-hidden">
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-border px-4 pt-4">
+          {tabs.map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              role="tab"
+              aria-selected={tabActiva === tab.value}
+              onClick={() => setTabActiva(tab.value)}
+              className={cn(
+                'px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px',
+                tabActiva === tab.value
+                  ? 'border-finza-blue text-finza-blue'
+                  : 'border-transparent text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
 
-        <CardContent>
+        <div className="p-0">
           {/* Error state */}
           {isError && (
-            <p className="text-sm text-gray-400 text-center py-4">
+            <p className="text-sm text-[var(--text-muted)] text-center py-4 px-4">
               El servidor no esta disponible. La lista se mostrara cuando el backend responda.
             </p>
           )}
@@ -195,9 +211,9 @@ export function PrestamosPage(): JSX.Element {
 
           {/* Lista */}
           {!isLoading && !isError && prestamosOrdenados.length > 0 && (
-            <CardTitle className="sr-only">
+            <span className="sr-only">
               Lista de prestamos — {tabActiva === 'me_deben' ? 'Me deben' : 'Yo debo'}
-            </CardTitle>
+            </span>
           )}
           {!isLoading && prestamosOrdenados.map((prestamo) => (
             <PrestamoRow
@@ -206,8 +222,8 @@ export function PrestamosPage(): JSX.Element {
               onClick={handleOpenDetail}
             />
           ))}
-        </CardContent>
-      </Card>
+        </div>
+      </div>
 
       {/* Modal crear */}
       <PrestamoModal

--- a/frontend/src/pages/PresupuestosPage.tsx
+++ b/frontend/src/pages/PresupuestosPage.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Plus, Target } from 'lucide-react'
 import axios from 'axios'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { PresupuestoCard } from '@/features/presupuestos/components/PresupuestoCard'
 import { PresupuestoModal } from '@/features/presupuestos/components/PresupuestoModal'
 import type { PresupuestoFormData } from '@/features/presupuestos/components/PresupuestoForm'
@@ -12,14 +15,8 @@ import {
   useDeletePresupuesto,
 } from '@/hooks/usePresupuestos'
 import { useCategorias } from '@/hooks/useCategorias'
+import { formatCurrency, MESES } from '@/lib/utils'
 import type { PresupuestoEstado } from '@/types/presupuesto'
-
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-const MESES = [
-  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
-  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
-]
 
 function getDefaultMesYear(): { mes: number; year: number } {
   const now = new Date()
@@ -30,42 +27,44 @@ function getYearOptions(currentYear: number): number[] {
   return [currentYear - 1, currentYear, currentYear + 1]
 }
 
-// ─── Sub-components ─────────────────────────────────────────────────────────
-
 function SkeletonCard(): JSX.Element {
   return (
     <div className="finza-card animate-pulse">
       <div className="flex items-start justify-between gap-2 mb-3">
-        <div className="h-4 w-32 bg-gray-200 rounded" />
-        <div className="h-5 w-16 bg-gray-200 rounded-full" />
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-5 w-16 rounded-full" />
       </div>
       <div className="flex justify-between mb-2">
-        <div className="h-6 w-24 bg-gray-200 rounded" />
-        <div className="h-4 w-20 bg-gray-200 rounded" />
+        <Skeleton className="h-6 w-24" />
+        <Skeleton className="h-4 w-20" />
       </div>
-      <div className="h-2.5 w-full bg-gray-200 rounded-full" />
-      <div className="h-3 w-12 bg-gray-200 rounded mt-1" />
+      <Skeleton className="h-2.5 w-full rounded-full" />
+      <Skeleton className="h-3 w-12 mt-1" />
     </div>
   )
 }
 
-function EmptyState(): JSX.Element {
+function EmptyState({ onNew }: { onNew: () => void }): JSX.Element {
+  const { t } = useTranslation()
   return (
     <div className="col-span-2 flex flex-col items-center justify-center py-16 text-center">
-      <Target size={48} className="text-gray-300 mb-4" aria-hidden="true" />
-      <p className="text-sm font-medium text-gray-500">
-        No hay presupuestos asignados para este mes
+      <Target size={48} className="text-[var(--text-muted)] opacity-40 mb-4" aria-hidden="true" />
+      <p className="text-sm font-medium text-[var(--text-primary)]">
+        {t('presupuestos.noPresupuestos')}
       </p>
-      <p className="text-xs text-gray-400 mt-1">
-        Crea tu primer presupuesto con el boton &ldquo;+ Nuevo&rdquo;
+      <p className="text-xs text-[var(--text-muted)] mt-1 mb-4">
+        {t('presupuestos.noPresupuestosDesc')}
       </p>
+      <Button onClick={onNew} size="md">
+        <Plus size={16} />
+        {t('presupuestos.newPresupuesto')}
+      </Button>
     </div>
   )
 }
 
-// ─── Main page ───────────────────────────────────────────────────────────────
-
 export function PresupuestosPage(): JSX.Element {
+  const { t } = useTranslation()
   const defaults = getDefaultMesYear()
   const [mes, setMes] = useState<number>(defaults.mes)
   const [year, setYear] = useState<number>(defaults.year)
@@ -88,6 +87,20 @@ export function PresupuestosPage(): JSX.Element {
       (cat.tipo === 'egreso' || cat.tipo === 'ambos') &&
       !categoriasConPresupuestoIds.has(cat.id)
   )
+
+  const currentYear = defaults.year
+  const yearOptions = getYearOptions(currentYear)
+
+  // Summary totals
+  const totalPresupuestado = useMemo(
+    () => estadoList.reduce((sum, e) => sum + e.monto_limite, 0),
+    [estadoList]
+  )
+  const totalGastado = useMemo(
+    () => estadoList.reduce((sum, e) => sum + e.gasto_actual, 0),
+    [estadoList]
+  )
+  const disponible = totalPresupuestado - totalGastado
 
   const handleOpenCreate = (): void => {
     setPreselectedCategoriaId(undefined)
@@ -127,11 +140,13 @@ export function PresupuestosPage(): JSX.Element {
         monto_limite: data.monto_limite,
       })
       handleCloseModal()
+      toast.success(t('presupuestos.created'))
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 409) {
         setFormError('Ya existe un presupuesto para esta categoria en este mes')
       } else {
         setFormError('Error al crear el presupuesto. Intenta de nuevo.')
+        toast.error(t('common.error'))
       }
     }
   }
@@ -145,45 +160,46 @@ export function PresupuestosPage(): JSX.Element {
         monto_limite: data.monto_limite,
       })
       handleCloseEdit()
+      toast.success(t('presupuestos.updated'))
     } catch (_error) {
       setFormError('Error al actualizar el presupuesto. Intenta de nuevo.')
+      toast.error(t('common.error'))
     }
   }
 
   const handleDelete = async (): Promise<void> => {
     if (!editingEstado) return
     if (window.confirm('Eliminar este presupuesto?')) {
-      await deletePresupuesto.mutateAsync(editingEstado.id)
-      handleCloseEdit()
+      try {
+        await deletePresupuesto.mutateAsync(editingEstado.id)
+        handleCloseEdit()
+        toast.success(t('presupuestos.deleted'))
+      } catch {
+        toast.error(t('common.error'))
+      }
     }
   }
 
-  const currentYear = defaults.year
-  const yearOptions = getYearOptions(currentYear)
-
   return (
-    <div>
+    <div className="animate-fade-in">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Presupuestos</h1>
-          <p className="text-gray-500 text-sm mt-1">
+          <h1 className="text-2xl font-bold text-[var(--text-primary)]">{t('presupuestos.title')}</h1>
+          <p className="text-[var(--text-muted)] text-sm mt-1">
             Controla tus limites de gasto por categoria
           </p>
         </div>
-        <Button onClick={handleOpenCreate} variant="default">
-          <Plus size={18} className="mr-2" />
-          Nuevo
+        <Button onClick={handleOpenCreate} variant="default" size="md">
+          <Plus size={16} />
+          {t('common.new')}
         </Button>
       </div>
 
       {/* Selector de mes / año */}
       <div className="flex items-center gap-3 mb-6">
         <div className="flex flex-col gap-1">
-          <label
-            htmlFor="mes-selector"
-            className="text-xs text-gray-500 font-medium"
-          >
+          <label htmlFor="mes-selector" className="text-xs text-[var(--text-muted)] font-medium">
             Mes
           </label>
           <select
@@ -200,10 +216,7 @@ export function PresupuestosPage(): JSX.Element {
           </select>
         </div>
         <div className="flex flex-col gap-1">
-          <label
-            htmlFor="year-selector"
-            className="text-xs text-gray-500 font-medium"
-          >
+          <label htmlFor="year-selector" className="text-xs text-[var(--text-muted)] font-medium">
             Año
           </label>
           <select
@@ -221,9 +234,33 @@ export function PresupuestosPage(): JSX.Element {
         </div>
       </div>
 
+      {/* Summary cards */}
+      {!isError && !isLoading && estadoList.length > 0 && (
+        <div className="grid grid-cols-3 gap-4 mb-6">
+          <div className="finza-card">
+            <p className="text-xs text-[var(--text-muted)] mb-1">{t('presupuestos.budgeted')}</p>
+            <p className="text-lg font-bold font-mono text-[var(--text-primary)]">
+              {formatCurrency(totalPresupuestado)}
+            </p>
+          </div>
+          <div className="finza-card">
+            <p className="text-xs text-[var(--text-muted)] mb-1">{t('presupuestos.spent')}</p>
+            <p className="text-lg font-bold font-mono text-[var(--text-primary)]">
+              {formatCurrency(totalGastado)}
+            </p>
+          </div>
+          <div className="finza-card">
+            <p className="text-xs text-[var(--text-muted)] mb-1">{t('presupuestos.available')}</p>
+            <p className={`text-lg font-bold font-mono ${disponible >= 0 ? 'text-prosperity-green' : 'text-alert-red'}`}>
+              {formatCurrency(Math.abs(disponible))}
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Error state */}
       {isError && (
-        <p className="text-sm text-gray-400 text-center py-4 mb-4">
+        <p className="text-sm text-[var(--text-muted)] text-center py-4 mb-4">
           El servidor no esta disponible. Los presupuestos se mostraran cuando
           el backend responda.
         </p>
@@ -232,7 +269,7 @@ export function PresupuestosPage(): JSX.Element {
       {/* Seccion: Con presupuesto */}
       {!isError && (
         <>
-          <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">
+          <h2 className="text-sm font-semibold text-[var(--text-muted)] uppercase tracking-wide mb-3">
             Con presupuesto asignado
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
@@ -243,7 +280,9 @@ export function PresupuestosPage(): JSX.Element {
                 <SkeletonCard />
               </>
             )}
-            {!isLoading && estadoList.length === 0 && <EmptyState />}
+            {!isLoading && estadoList.length === 0 && (
+              <EmptyState onNew={handleOpenCreate} />
+            )}
             {!isLoading &&
               estadoList.map((estado) => (
                 <PresupuestoCard
@@ -257,7 +296,7 @@ export function PresupuestosPage(): JSX.Element {
           {/* Seccion: Sin presupuesto */}
           {!isLoading && categoriasSinPresupuesto.length > 0 && (
             <>
-              <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">
+              <h2 className="text-sm font-semibold text-[var(--text-muted)] uppercase tracking-wide mb-3">
                 Sin presupuesto
               </h2>
               <div className="finza-card p-0 overflow-hidden">
@@ -270,7 +309,7 @@ export function PresupuestosPage(): JSX.Element {
                         : ''
                     }`}
                   >
-                    <span className="text-sm text-gray-700">
+                    <span className="text-sm text-[var(--text-primary)]">
                       {cat.icono ? `${cat.icono} ` : ''}
                       {cat.nombre}
                     </span>

--- a/frontend/src/pages/__tests__/EgresosPage.test.tsx
+++ b/frontend/src/pages/__tests__/EgresosPage.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EgresosPage } from '@/pages/EgresosPage'
+import type { EgresoResponse, PaginatedResponse, CategoriaResponse } from '@/types/transacciones'
+
+vi.mock('@/hooks/useEgresos', () => ({
+  useEgresos: vi.fn(),
+  useCreateEgreso: vi.fn(),
+  useDeleteEgreso: vi.fn(),
+}))
+
+vi.mock('@/hooks/useCategorias', () => ({
+  useCategorias: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { useEgresos, useCreateEgreso, useDeleteEgreso } from '@/hooks/useEgresos'
+import { useCategorias } from '@/hooks/useCategorias'
+import { toast } from 'sonner'
+
+const mockCategorias: CategoriaResponse[] = [
+  { id: 'cat-1', nombre: 'Alimentacion', tipo: 'egreso', icono: null, color: null, es_sistema: true },
+]
+
+// Helper to build a date in current month/year for local timezone
+function currentMonthDate(day: number): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth() + 1
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T12:00:00`
+}
+
+const mockEgresos: EgresoResponse[] = [
+  {
+    id: 'egr-1',
+    categoria_id: 'cat-1',
+    subcategoria_id: null,
+    monto: '3000.00',
+    moneda: 'DOP',
+    descripcion: 'Supermercado',
+    metodo_pago: 'efectivo',
+    fecha: currentMonthDate(5),
+    notas: null,
+  },
+  {
+    id: 'egr-2',
+    categoria_id: 'cat-1',
+    subcategoria_id: null,
+    monto: '500.00',
+    moneda: 'DOP',
+    descripcion: 'Farmacia Local',
+    metodo_pago: 'tarjeta',
+    fecha: currentMonthDate(10),
+    notas: null,
+  },
+]
+
+const mockPaginatedData: PaginatedResponse<EgresoResponse> = {
+  items: mockEgresos,
+  total: 2,
+  page: 1,
+  page_size: 200,
+  has_next: false,
+}
+
+function setupMocks({
+  data = mockPaginatedData,
+  isLoading = false,
+}: {
+  data?: PaginatedResponse<EgresoResponse> | undefined
+  isLoading?: boolean
+} = {}) {
+  vi.mocked(useEgresos).mockReturnValue({
+    data,
+    isLoading,
+    isPending: isLoading,
+    isSuccess: !isLoading,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof useEgresos>)
+
+  vi.mocked(useCategorias).mockReturnValue({
+    data: mockCategorias,
+    isLoading: false,
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof useCategorias>)
+
+  vi.mocked(useCreateEgreso).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCreateEgreso>)
+
+  vi.mocked(useDeleteEgreso).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDeleteEgreso>)
+}
+
+describe('EgresosPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders correctly with default props', () => {
+    render(<EgresosPage />)
+    expect(screen.getByText('Egresos')).toBeInTheDocument()
+  })
+
+  it('shows loading state while fetching', () => {
+    setupMocks({ isLoading: true, data: undefined })
+    render(<EgresosPage />)
+    const pulsingElements = document.querySelectorAll('.animate-pulse')
+    expect(pulsingElements.length).toBeGreaterThan(0)
+  })
+
+  it('shows empty state when no data', () => {
+    setupMocks({
+      data: { items: [], total: 0, page: 1, page_size: 200, has_next: false },
+    })
+    render(<EgresosPage />)
+    expect(screen.getByText(/no hay egresos registrados este mes/i)).toBeInTheDocument()
+  })
+
+  it('displays data correctly when loaded', () => {
+    render(<EgresosPage />)
+    expect(screen.getByText('Supermercado')).toBeInTheDocument()
+    expect(screen.getByText('Farmacia Local')).toBeInTheDocument()
+  })
+
+  it('renders stats cards', () => {
+    render(<EgresosPage />)
+    expect(screen.getByText('Total del mes')).toBeInTheDocument()
+    expect(screen.getByText('Transacciones')).toBeInTheDocument()
+  })
+
+  it('renders nuevo egreso button', () => {
+    render(<EgresosPage />)
+    const buttons = screen.getAllByRole('button', { name: /nuevo egreso/i })
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  it('handles user interaction: search filter filters by description', () => {
+    render(<EgresosPage />)
+    const searchInput = screen.getByPlaceholderText(/buscar/i)
+    fireEvent.change(searchInput, { target: { value: 'Supermercado' } })
+    expect(screen.getByText('Supermercado')).toBeInTheDocument()
+    expect(screen.queryByText('Farmacia Local')).not.toBeInTheDocument()
+  })
+
+  it('calls callbacks with correct arguments on delete', async () => {
+    const mockDeleteFn = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useDeleteEgreso).mockReturnValue({
+      mutateAsync: mockDeleteFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDeleteEgreso>)
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<EgresosPage />)
+    const deleteButtons = screen.getAllByLabelText('Eliminar')
+    fireEvent.click(deleteButtons[0])
+
+    await waitFor(() => {
+      expect(mockDeleteFn).toHaveBeenCalledWith('egr-1')
+    })
+  })
+
+  it('shows toast success on delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<EgresosPage />)
+    const deleteButtons = screen.getAllByLabelText('Eliminar')
+    fireEvent.click(deleteButtons[0])
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+  })
+
+  it('renders amounts with negative sign for expenses', () => {
+    render(<EgresosPage />)
+    const negativeAmounts = screen.getAllByText(/^-RD\$/)
+    expect(negativeAmounts.length).toBeGreaterThan(0)
+  })
+
+  it('renders month filter selector', () => {
+    render(<EgresosPage />)
+    expect(screen.getByLabelText('Mes')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/IngresosPage.test.tsx
+++ b/frontend/src/pages/__tests__/IngresosPage.test.tsx
@@ -1,0 +1,210 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { IngresosPage } from '@/pages/IngresosPage'
+import type { IngresoResponse, PaginatedResponse } from '@/types/transacciones'
+import type { CategoriaResponse } from '@/types/transacciones'
+
+vi.mock('@/hooks/useIngresos', () => ({
+  useIngresos: vi.fn(),
+  useCreateIngreso: vi.fn(),
+  useDeleteIngreso: vi.fn(),
+}))
+
+vi.mock('@/hooks/useCategorias', () => ({
+  useCategorias: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { useIngresos, useCreateIngreso, useDeleteIngreso } from '@/hooks/useIngresos'
+import { useCategorias } from '@/hooks/useCategorias'
+import { toast } from 'sonner'
+
+const mockCategorias: CategoriaResponse[] = [
+  { id: 'cat-1', nombre: 'Salario', tipo: 'ingreso', icono: null, color: null, es_sistema: true },
+]
+
+// Helper to build a date in current month/year for local timezone
+function currentMonthDate(day: number): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth() + 1
+  // Use T12:00:00 to avoid UTC date edge issues
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}T12:00:00`
+}
+
+const mockIngresos: IngresoResponse[] = [
+  {
+    id: 'ing-1',
+    categoria_id: 'cat-1',
+    subcategoria_id: null,
+    monto: '5000.00',
+    moneda: 'DOP',
+    descripcion: 'Salario mensual',
+    fuente: null,
+    fecha: currentMonthDate(1),
+    notas: null,
+  },
+  {
+    id: 'ing-2',
+    categoria_id: 'cat-1',
+    subcategoria_id: null,
+    monto: '1200.00',
+    moneda: 'DOP',
+    descripcion: 'Freelance Extra',
+    fuente: null,
+    fecha: currentMonthDate(15),
+    notas: null,
+  },
+]
+
+const mockPaginatedData: PaginatedResponse<IngresoResponse> = {
+  items: mockIngresos,
+  total: 2,
+  page: 1,
+  page_size: 200,
+  has_next: false,
+}
+
+function setupMocks({
+  data = mockPaginatedData,
+  isLoading = false,
+}: {
+  data?: PaginatedResponse<IngresoResponse> | undefined
+  isLoading?: boolean
+} = {}) {
+  vi.mocked(useIngresos).mockReturnValue({
+    data,
+    isLoading,
+    isPending: isLoading,
+    isSuccess: !isLoading,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof useIngresos>)
+
+  vi.mocked(useCategorias).mockReturnValue({
+    data: mockCategorias,
+    isLoading: false,
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+  } as ReturnType<typeof useCategorias>)
+
+  vi.mocked(useCreateIngreso).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCreateIngreso>)
+
+  vi.mocked(useDeleteIngreso).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDeleteIngreso>)
+}
+
+describe('IngresosPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders correctly with default props', () => {
+    render(<IngresosPage />)
+    expect(screen.getByText('Ingresos')).toBeInTheDocument()
+  })
+
+  it('shows loading state while fetching', () => {
+    setupMocks({ isLoading: true, data: undefined })
+    render(<IngresosPage />)
+    const pulsingElements = document.querySelectorAll('.animate-pulse')
+    expect(pulsingElements.length).toBeGreaterThan(0)
+  })
+
+  it('shows empty state when no data', () => {
+    setupMocks({
+      data: { items: [], total: 0, page: 1, page_size: 200, has_next: false },
+    })
+    render(<IngresosPage />)
+    expect(screen.getByText(/no hay ingresos registrados este mes/i)).toBeInTheDocument()
+  })
+
+  it('displays data correctly when loaded', () => {
+    render(<IngresosPage />)
+    expect(screen.getByText('Salario mensual')).toBeInTheDocument()
+    expect(screen.getByText('Freelance Extra')).toBeInTheDocument()
+  })
+
+  it('renders stats cards', () => {
+    render(<IngresosPage />)
+    expect(screen.getByText('Total del mes')).toBeInTheDocument()
+    expect(screen.getByText('Transacciones')).toBeInTheDocument()
+  })
+
+  it('renders nuevo ingreso button in header', () => {
+    render(<IngresosPage />)
+    const buttons = screen.getAllByRole('button', { name: /nuevo ingreso/i })
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  it('renders month filter selector', () => {
+    render(<IngresosPage />)
+    expect(screen.getByLabelText('Mes')).toBeInTheDocument()
+  })
+
+  it('handles user interaction: search filter filters by description', () => {
+    render(<IngresosPage />)
+    const searchInput = screen.getByPlaceholderText(/buscar/i)
+    // 'mensual' is unique to 'Salario mensual' — does not match 'Freelance Extra'
+    fireEvent.change(searchInput, { target: { value: 'mensual' } })
+    expect(screen.getByText('Salario mensual')).toBeInTheDocument()
+    expect(screen.queryByText('Freelance Extra')).not.toBeInTheDocument()
+  })
+
+  it('shows delete buttons for each row', () => {
+    render(<IngresosPage />)
+    const deleteButtons = screen.getAllByLabelText('Eliminar')
+    expect(deleteButtons).toHaveLength(2)
+  })
+
+  it('calls delete with correct id on confirmation', async () => {
+    const mockDeleteFn = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useDeleteIngreso).mockReturnValue({
+      mutateAsync: mockDeleteFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDeleteIngreso>)
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<IngresosPage />)
+    const deleteButtons = screen.getAllByLabelText('Eliminar')
+    fireEvent.click(deleteButtons[0])
+
+    await waitFor(() => {
+      expect(mockDeleteFn).toHaveBeenCalledWith('ing-1')
+    })
+  })
+
+  it('shows toast success on successful delete', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<IngresosPage />)
+    const deleteButtons = screen.getAllByLabelText('Eliminar')
+    fireEvent.click(deleteButtons[0])
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled()
+    })
+  })
+
+  it('renders amounts with positive sign in table', () => {
+    render(<IngresosPage />)
+    // Income amounts show with '+' prefix
+    const amountCells = screen.getAllByText(/^\+RD\$/)
+    expect(amountCells.length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import es from '@/i18n/locales/es'
+import en from '@/i18n/locales/en'
+
+if (!i18n.isInitialized) {
+  i18n.use(initReactI18next).init({
+    resources: { es: { translation: es }, en: { translation: en } },
+    lng: 'es',
+    fallbackLng: 'es',
+    interpolation: { escapeValue: false },
+  })
+}


### PR DESCRIPTION
Closes #66

## Changes

- **DashboardPage**: semantic tokens (`text-[var(--text-primary)]`, `text-[var(--text-muted)]`), `<Skeleton />` loaders for KPI cards and sections, `animate-fade-in` entry animation, i18n via `useTranslation()`, empty state with `BarChart3` icon
- **IngresosPage**: full redesign — stats cards (total mes + count), month/year selector + search filter, modern table with zebra banding + `Badge` for category, `+formatCurrency` amounts in `text-prosperity-green`, toasts on create/delete, empty state with `TrendingUp` icon
- **EgresosPage**: identical structure to Ingresos with expense styling (`text-alert-red`, `-` prefix), toasts, empty state with `TrendingDown` icon
- **PrestamosPage**: dark mode tokens throughout, toast feedback on create/update/delete, `finza-card` wrapper replacing `Card`, `Skeleton` loading state
- **MetasPage**: i18n, `Skeleton` loaders, toast feedback on CRUD, updated empty state using `metas.noMetas` i18n key
- **PresupuestosPage**: 3-column summary cards (presupuestado/gastado/disponible — green if positive, red if negative), toasts on create/update/delete, i18n
- **utils.ts**: add `formatCurrency` alias + `MESES` constant export
- **Dark mode pass**: `KpiCard`, `MetaCard`, `PresupuestoCard`, `TransaccionRow`, `MetasResumenCards`, `PrestamoResumenCards` — all hardcoded `text-gray-*` replaced with semantic tokens
- **test/setup.ts**: initialize i18n real instance for test environment

## Tests

- 240 tests total, 240 passing
- 23 new tests added: `IngresosPage.test.tsx` (12) + `EgresosPage.test.tsx` (11)
- Updated 5 existing test files for i18n text key changes
- Coverage: loading state, empty state, data display, search filter, delete with toast, negative/positive amount styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)