### PR TITLE
fix(backend): raise page_size max from 100 to 500 in ingresos and egresos

### DIFF
--- a/backend/app/api/v1/routes/egresos.py
+++ b/backend/app/api/v1/routes/egresos.py
@@ -18,7 +18,7 @@ async def list_egresos(
     categoria_id: UUID | None = Query(None),
     moneda: str | None = Query(None),
     page: int = Query(1, ge=1),
-    page_size: int = Query(20, ge=1, le=100),
+    page_size: int = Query(20, ge=1, le=500),
     token: str = Depends(get_raw_token),
     current_user: dict = Depends(get_current_user),
 ) -> dict:

--- a/backend/app/api/v1/routes/ingresos.py
+++ b/backend/app/api/v1/routes/ingresos.py
@@ -18,7 +18,7 @@ async def list_ingresos(
     categoria_id: UUID | None = Query(None),
     moneda: str | None = Query(None),
     page: int = Query(1, ge=1),
-    page_size: int = Query(20, ge=1, le=100),
+    page_size: int = Query(20, ge=1, le=500),
     token: str = Depends(get_raw_token),
     current_user: dict = Depends(get_current_user),
 ) -> dict:


### PR DESCRIPTION
Closes #71

## Problem
`IngresosPage` and `EgresosPage` send `page_size=200` in their requests. The backend had the parameter constrained to `le=100`, causing FastAPI to return 422 Unprocessable Entity and data to never reach the frontend.

## Changes
- `backend/app/api/v1/routes/ingresos.py`: `page_size` max raised from `le=100` to `le=500`
- `backend/app/api/v1/routes/egresos.py`: `page_size` max raised from `le=100` to `le=500`

## Tests
No existing tests validated the `le=100` boundary (grep confirmed). No test updates required.