### PR TITLE
fix(backend): add user_id to presupuesto/meta creation, flatten prestamos resumen, raise page_size limit

### DIFF
--- a/backend/app/api/v1/routes/metas.py
+++ b/backend/app/api/v1/routes/metas.py
@@ -33,7 +33,7 @@ async def create_meta(
     token: str = Depends(get_raw_token),
     current_user: dict = Depends(get_current_user),
 ) -> dict:
-    return svc.create_meta(user_jwt=token, data=data)
+    return svc.create_meta(user_jwt=token, user_id=current_user["user_id"], data=data)
 
 
 # IMPORTANTE: /resumen debe ir ANTES de /{meta_id} para evitar que el

--- a/backend/app/api/v1/routes/presupuestos.py
+++ b/backend/app/api/v1/routes/presupuestos.py
@@ -30,7 +30,7 @@ async def create_presupuesto(
     token: str = Depends(get_raw_token),
     current_user: dict = Depends(get_current_user),
 ) -> dict:
-    return svc.create_presupuesto(user_jwt=token, data=data)
+    return svc.create_presupuesto(user_jwt=token, user_id=current_user["user_id"], data=data)
 
 
 # IMPORTANTE: /estado debe ir ANTES de /{presupuesto_id} para evitar que el

--- a/backend/app/schemas/prestamo.py
+++ b/backend/app/schemas/prestamo.py
@@ -104,15 +104,8 @@ class PrestamoResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class PrestamoResumenTipo(BaseModel):
-    cantidad: int
-    monto_original_total: Decimal
-    monto_pendiente_total: Decimal
-
-
 class PrestamoResumen(BaseModel):
-    me_deben: PrestamoResumenTipo
-    yo_debo: PrestamoResumenTipo
-    total_activos: int
-    total_pagados: int
-    total_vencidos: int
+    total_me_deben: float
+    total_yo_debo: float
+    cantidad_activos: int
+    cantidad_vencidos: int

--- a/backend/app/services/metas_ahorro.py
+++ b/backend/app/services/metas_ahorro.py
@@ -46,9 +46,10 @@ def get_meta_by_id(user_jwt: str, meta_id: str) -> dict:
     return {}
 
 
-def create_meta(user_jwt: str, data: MetaAhorroCreate) -> dict:
+def create_meta(user_jwt: str, user_id: str, data: MetaAhorroCreate) -> dict:
     client = get_user_client(user_jwt)
     payload = data.model_dump()
+    payload["user_id"] = user_id
     payload["monto_objetivo"] = str(payload["monto_objetivo"])
     payload["fecha_inicio"] = str(payload["fecha_inicio"])
     if payload.get("fecha_objetivo"):

--- a/backend/app/services/prestamos.py
+++ b/backend/app/services/prestamos.py
@@ -302,26 +302,15 @@ def get_resumen(user_jwt: str, user_id: str) -> dict:
         yo_debo_activos = [
             p for p in prestamos if p["tipo"] == "yo_debo" and p["estado"] == "activo"
         ]
-        me_deben_todos = [p for p in prestamos if p["tipo"] == "me_deben"]
-        yo_debo_todos = [p for p in prestamos if p["tipo"] == "yo_debo"]
 
         def sumar(lista: list[dict], campo: str) -> Decimal:
             return sum(Decimal(str(p[campo])) for p in lista)
 
         return {
-            "me_deben": {
-                "cantidad": len(me_deben_todos),
-                "monto_original_total": str(sumar(me_deben_todos, "monto_original")),
-                "monto_pendiente_total": str(sumar(me_deben_activos, "monto_pendiente")),
-            },
-            "yo_debo": {
-                "cantidad": len(yo_debo_todos),
-                "monto_original_total": str(sumar(yo_debo_todos, "monto_original")),
-                "monto_pendiente_total": str(sumar(yo_debo_activos, "monto_pendiente")),
-            },
-            "total_activos": sum(1 for p in prestamos if p["estado"] == "activo"),
-            "total_pagados": sum(1 for p in prestamos if p["estado"] == "pagado"),
-            "total_vencidos": sum(1 for p in prestamos if p["estado"] == "vencido"),
+            "total_me_deben": float(sumar(me_deben_activos, "monto_pendiente")),
+            "total_yo_debo": float(sumar(yo_debo_activos, "monto_pendiente")),
+            "cantidad_activos": sum(1 for p in prestamos if p["estado"] == "activo"),
+            "cantidad_vencidos": sum(1 for p in prestamos if p["estado"] == "vencido"),
         }
     except APIError as e:
         _handle_api_error(e)

--- a/backend/app/services/presupuestos.py
+++ b/backend/app/services/presupuestos.py
@@ -53,9 +53,10 @@ def get_presupuesto_by_id(user_jwt: str, presupuesto_id: str) -> dict:
     return {}
 
 
-def create_presupuesto(user_jwt: str, data: PresupuestoCreate) -> dict:
+def create_presupuesto(user_jwt: str, user_id: str, data: PresupuestoCreate) -> dict:
     client = get_user_client(user_jwt)
     payload = {
+        "user_id": user_id,
         "categoria_id": str(data.categoria_id),
         "mes": data.mes,
         "year": data.year,

--- a/backend/tests/test_metas.py
+++ b/backend/tests/test_metas.py
@@ -85,10 +85,11 @@ def test_create_meta_success():
     )
 
     with patch("app.services.metas_ahorro.get_user_client", return_value=mock_client):
-        result = create_meta("fake-jwt", data)
+        result = create_meta("fake-jwt", "u1", data)
 
     assert result["id"] == "aaaa-1111"
     insert_payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert insert_payload["user_id"] == "u1"
     assert insert_payload["nombre"] == "Vacaciones"
     assert insert_payload["monto_objetivo"] == "30000.00"
 
@@ -496,6 +497,6 @@ def test_create_meta_api_error_raises_http():
 
     with patch("app.services.metas_ahorro.get_user_client", return_value=mock_client):
         with pytest.raises(HTTPException) as exc_info:
-            create_meta("fake-jwt", data)
+            create_meta("fake-jwt", "u1", data)
 
     assert exc_info.value.status_code == 400

--- a/backend/tests/test_prestamos.py
+++ b/backend/tests/test_prestamos.py
@@ -253,7 +253,7 @@ def test_registrar_pago_excede_pendiente_raises_400():
 
 
 def test_get_resumen_estructura():
-    """get_resumen returns the expected PrestamoResumen structure."""
+    """get_resumen returns the expected flat PrestamoResumen structure."""
     from app.services.prestamos import get_resumen
 
     prestamos_data = [
@@ -294,29 +294,20 @@ def test_get_resumen_estructura():
     with patch("app.services.prestamos.get_user_client", return_value=mock_client):
         result = get_resumen("fake-jwt", "u1")
 
-    # Estructura base
-    assert "me_deben" in result
-    assert "yo_debo" in result
-    assert "total_activos" in result
-    assert "total_pagados" in result
-    assert "total_vencidos" in result
+    # Flat structure
+    assert "total_me_deben" in result
+    assert "total_yo_debo" in result
+    assert "cantidad_activos" in result
+    assert "cantidad_vencidos" in result
 
-    # Conteos por estado
-    assert result["total_activos"] == 2   # 1 me_deben activo + 1 yo_debo activo
-    assert result["total_pagados"] == 1   # 1 me_deben pagado
-    assert result["total_vencidos"] == 1  # 1 yo_debo vencido
-
-    # me_deben: 2 en total (activo + pagado)
-    assert result["me_deben"]["cantidad"] == 2
-    assert Decimal(result["me_deben"]["monto_original_total"]) == Decimal("1500.00")
-    # monto_pendiente_total solo cuenta activos
-    assert Decimal(result["me_deben"]["monto_pendiente_total"]) == Decimal("700.00")
-
-    # yo_debo: 2 en total (activo + vencido)
-    assert result["yo_debo"]["cantidad"] == 2
-    assert Decimal(result["yo_debo"]["monto_original_total"]) == Decimal("2300.00")
-    # monto_pendiente_total solo cuenta activos
-    assert Decimal(result["yo_debo"]["monto_pendiente_total"]) == Decimal("2000.00")
+    # total_me_deben: solo activos con monto_pendiente
+    assert result["total_me_deben"] == 700.0
+    # total_yo_debo: solo activos con monto_pendiente
+    assert result["total_yo_debo"] == 2000.0
+    # cantidad_activos: 1 me_deben activo + 1 yo_debo activo
+    assert result["cantidad_activos"] == 2
+    # cantidad_vencidos: 1 yo_debo vencido
+    assert result["cantidad_vencidos"] == 1
 
 
 def test_delete_prestamo_soft_delete():

--- a/backend/tests/test_presupuestos.py
+++ b/backend/tests/test_presupuestos.py
@@ -115,10 +115,11 @@ def test_create_presupuesto_success():
     with patch(
         "app.services.presupuestos.get_user_client", return_value=mock_client
     ):
-        result = create_presupuesto("fake-jwt", data)
+        result = create_presupuesto("fake-jwt", "u1", data)
 
     assert result["id"] == "aaaa-0001"
     insert_payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert insert_payload["user_id"] == "u1"
     assert insert_payload["mes"] == 3
     assert insert_payload["year"] == 2026
     assert insert_payload["monto_limite"] == 5000.0
@@ -145,7 +146,7 @@ def test_create_presupuesto_duplicate_raises_409():
         "app.services.presupuestos.get_user_client", return_value=mock_client
     ):
         with pytest.raises(HTTPException) as exc_info:
-            create_presupuesto("fake-jwt", data)
+            create_presupuesto("fake-jwt", "u1", data)
 
     assert exc_info.value.status_code == 409
     assert "categoria" in exc_info.value.detail.lower()
@@ -543,6 +544,6 @@ def test_create_presupuesto_api_error_raises_http():
         "app.services.presupuestos.get_user_client", return_value=mock_client
     ):
         with pytest.raises(HTTPException) as exc_info:
-            create_presupuesto("fake-jwt", data)
+            create_presupuesto("fake-jwt", "u1", data)
 
     assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary
- Add `user_id` to `create_presupuesto` service (fixes NOT NULL constraint violation → HTTP 500)
- Add `user_id` to `create_meta` service (fixes NOT NULL constraint violation → HTTP 500)
- Flatten `get_resumen` prestamos return to `{total_me_deben, total_yo_debo, cantidad_activos, cantidad_vencidos}` (fixes KPI cards showing $0.00)
- Update `PrestamoResumen` schema to match flat structure, remove `PrestamoResumenTipo`
- Raise `page_size` limit from 100 to 500 in ingresos/egresos routes (already applied in a prior fix, confirmed le=500)

## Test plan
- [ ] POST /presupuestos → 201 Created (no longer 500)
- [ ] POST /metas → 201 Created (no longer 500)
- [ ] GET /prestamos/resumen → returns flat {total_me_deben, total_yo_debo, cantidad_activos, cantidad_vencidos}
- [ ] GET /ingresos?page_size=200 → 200 OK (no longer 422)
- [ ] pytest -q → all green

🤖 Generated with Claude Code