### PR TITLE
fix(frontend): error messages, categorias CRUD page, pago feedback, presupuesto form states

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { EgresosPage } from '@/pages/EgresosPage'
 import { PrestamosPage } from '@/pages/PrestamosPage'
 import { MetasPage } from '@/pages/MetasPage'
 import { PresupuestosPage } from '@/pages/PresupuestosPage'
+import { CategoriasPage } from '@/pages/CategoriasPage'
 import { ConfiguracionPage } from '@/pages/ConfiguracionPage'
 
 const queryClient = new QueryClient({
@@ -67,6 +68,7 @@ export function App(): JSX.Element {
                 <Route path="/prestamos" element={<PrestamosPage />} />
                 <Route path="/metas" element={<MetasPage />} />
                 <Route path="/presupuestos" element={<PresupuestosPage />} />
+                <Route path="/categorias" element={<CategoriasPage />} />
                 <Route path="/reportes" element={<div className="p-4 text-[var(--text-primary)]">Reportes - Issue futuro</div>} />
                 <Route path="/configuracion" element={<ConfiguracionPage />} />
               </Route>

--- a/frontend/src/components/shared/Sidebar.tsx
+++ b/frontend/src/components/shared/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   ChevronLeft,
   ChevronRight,
   LogOut,
+  Tag,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useUiStore } from '@/store/uiStore'
@@ -26,6 +27,7 @@ const navItems = [
   { to: '/prestamos', icon: HandCoins, labelKey: 'nav.prestamos' },
   { to: '/metas', icon: PiggyBank, labelKey: 'nav.metas' },
   { to: '/presupuestos', icon: Target, labelKey: 'nav.presupuestos' },
+  { to: '/categorias', icon: Tag, labelKey: 'nav.categorias' },
   { to: '/reportes', icon: FileText, labelKey: 'nav.reportes' },
   { to: '/configuracion', icon: Settings, labelKey: 'nav.configuracion' },
 ]

--- a/frontend/src/features/prestamos/components/PrestamoDetail.tsx
+++ b/frontend/src/features/prestamos/components/PrestamoDetail.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react'
 import { X, Pencil, Trash2, Plus } from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { formatMoney, formatDate, cn } from '@/lib/utils'
 import { PagoForm } from './PagoForm'
 import type { PagoFormData } from './PagoForm'
 import { useDeletePago, useRegistrarPago, usePrestamoDetalle } from '@/hooks/usePrestamos'
 import type { Prestamo, EstadoPrestamo } from '@/types/prestamo'
+import { getApiErrorMessage } from '@/lib/apiError'
 
 interface PrestamoDetailProps {
   prestamoId: string
@@ -40,6 +43,7 @@ export function PrestamoDetail({
   onEdit,
   onDelete,
 }: PrestamoDetailProps): JSX.Element {
+  const { t } = useTranslation()
   const [showPagoForm, setShowPagoForm] = useState(false)
 
   const { data: prestamo, isLoading, isError } = usePrestamoDetalle(prestamoId)
@@ -49,8 +53,13 @@ export function PrestamoDetail({
   const displayPrestamo = prestamo ?? prestamoCache
 
   const handleRegistrarPago = async (data: PagoFormData): Promise<void> => {
-    await registrarPago.mutateAsync(data)
-    setShowPagoForm(false)
+    try {
+      await registrarPago.mutateAsync(data)
+      setShowPagoForm(false)
+      toast.success(t('prestamos.pagoRegistrado'))
+    } catch (error) {
+      toast.error(getApiErrorMessage(error))
+    }
   }
 
   const handleDeletePago = async (pagoId: string): Promise<void> => {

--- a/frontend/src/features/presupuestos/components/PresupuestoForm.tsx
+++ b/frontend/src/features/presupuestos/components/PresupuestoForm.tsx
@@ -97,7 +97,13 @@ export function PresupuestoForm({
             errors.categoria_id ? 'categoria-error' : undefined
           }
         >
-          <option value="">Selecciona una categoria...</option>
+          {loadingCategorias
+            ? <option value="">Cargando categorias...</option>
+            : <option value="">Selecciona una categoria...</option>
+          }
+          {!loadingCategorias && categoriasEgreso.length === 0 && (
+            <option value="" disabled>No hay categorias de egreso disponibles</option>
+          )}
           {categoriasEgreso.map((cat) => (
             <option key={cat.id} value={cat.id}>
               {cat.icono ? `${cat.icono} ` : ''}

--- a/frontend/src/hooks/useCategorias.ts
+++ b/frontend/src/hooks/useCategorias.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api'
 import type { CategoriaResponse } from '@/types/transacciones'
 
@@ -11,5 +11,37 @@ export function useCategorias(tipo?: 'ingreso' | 'egreso') {
       return data
     },
     staleTime: 10 * 60 * 1000, // 10 min — categorias no cambian seguido
+  })
+}
+
+export function useCreateCategoria() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: { nombre: string; tipo: 'ingreso' | 'egreso' | 'ambos'; icono?: string }) => {
+      const { data } = await apiClient.post('/categorias', payload)
+      return data
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categorias'] }),
+  })
+}
+
+export function useUpdateCategoria() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ id, ...payload }: { id: string; nombre?: string; tipo?: string; icono?: string }) => {
+      const { data } = await apiClient.put(`/categorias/${id}`, payload)
+      return data
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categorias'] }),
+  })
+}
+
+export function useDeleteCategoria() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      await apiClient.delete(`/categorias/${id}`)
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categorias'] }),
   })
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2,7 +2,7 @@ const en = {
   nav: {
     dashboard: 'Dashboard', ingresos: 'Income', egresos: 'Expenses',
     prestamos: 'Loans', metas: 'Goals', presupuestos: 'Budgets',
-    reportes: 'Reports', configuracion: 'Settings',
+    reportes: 'Reports', configuracion: 'Settings', categorias: 'Categories',
   },
   common: {
     save: 'Save', cancel: 'Cancel', create: 'Create', edit: 'Edit',
@@ -72,6 +72,7 @@ const en = {
     noPrestamosDesc: 'Record a loan to start tracking it',
     status: { pendiente: 'Pending', pagado: 'Paid', vencido: 'Overdue' },
     created: 'Loan recorded', updated: 'Loan updated', deleted: 'Loan deleted',
+    pagoRegistrado: 'Payment registered successfully',
   },
   metas: {
     title: 'Savings goals', newMeta: 'New goal',
@@ -88,6 +89,26 @@ const en = {
     noPresupuestos: 'No budgets', noPresupuestosDesc: 'Create a budget to control your spending',
     alert: 'Alert', exceeded: 'Exceeded',
     created: 'Budget created', updated: 'Budget updated', deleted: 'Budget deleted',
+  },
+  categorias: {
+    title: 'Categories',
+    subtitle: 'Manage your income and expense categories',
+    nueva: 'New category',
+    editarTitulo: 'Edit category',
+    nombre: 'Name',
+    tipo: 'Type',
+    icono: 'Icon (emoji)',
+    sistema: 'System',
+    personalizada: 'Custom',
+    created: 'Category created',
+    updated: 'Category updated',
+    deleted: 'Category deleted',
+    deleteConfirm: 'Delete this category? This action cannot be undone.',
+    noCategorias: 'No custom categories',
+    noCategoriasDesc: 'Create your first custom category',
+    ingreso: 'Income',
+    egreso: 'Expense',
+    ambos: 'Both',
   },
 }
 

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -2,7 +2,7 @@ const es = {
   nav: {
     dashboard: 'Dashboard', ingresos: 'Ingresos', egresos: 'Egresos',
     prestamos: 'Prestamos', metas: 'Metas', presupuestos: 'Presupuestos',
-    reportes: 'Reportes', configuracion: 'Configuracion',
+    reportes: 'Reportes', configuracion: 'Configuracion', categorias: 'Categorias',
   },
   common: {
     save: 'Guardar', cancel: 'Cancelar', create: 'Crear', edit: 'Editar',
@@ -73,6 +73,7 @@ const es = {
     noPrestamosDesc: 'Registra un prestamo para hacer seguimiento',
     status: { pendiente: 'Pendiente', pagado: 'Pagado', vencido: 'Vencido' },
     created: 'Prestamo registrado', updated: 'Prestamo actualizado', deleted: 'Prestamo eliminado',
+    pagoRegistrado: 'Pago registrado correctamente',
   },
   metas: {
     title: 'Metas de ahorro', newMeta: 'Nueva meta',
@@ -89,6 +90,26 @@ const es = {
     noPresupuestos: 'Sin presupuestos', noPresupuestosDesc: 'Crea un presupuesto para controlar tus gastos',
     alert: 'Alerta', exceeded: 'Excedido',
     created: 'Presupuesto creado', updated: 'Presupuesto actualizado', deleted: 'Presupuesto eliminado',
+  },
+  categorias: {
+    title: 'Categorias',
+    subtitle: 'Administra tus categorias de ingresos y egresos',
+    nueva: 'Nueva categoria',
+    editarTitulo: 'Editar categoria',
+    nombre: 'Nombre',
+    tipo: 'Tipo',
+    icono: 'Icono (emoji)',
+    sistema: 'Sistema',
+    personalizada: 'Personalizada',
+    created: 'Categoria creada',
+    updated: 'Categoria actualizada',
+    deleted: 'Categoria eliminada',
+    deleteConfirm: 'Eliminar esta categoria? Esta accion no se puede deshacer.',
+    noCategorias: 'Sin categorias personalizadas',
+    noCategoriasDesc: 'Crea tu primera categoria personalizada',
+    ingreso: 'Ingreso',
+    egreso: 'Egreso',
+    ambos: 'Ambos',
   },
 }
 

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -1,0 +1,10 @@
+import axios from 'axios'
+
+export function getApiErrorMessage(error: unknown, fallback = 'Error inesperado'): string {
+  if (axios.isAxiosError(error)) {
+    const detail = error.response?.data?.detail
+    if (typeof detail === 'string') return detail
+    if (Array.isArray(detail)) return detail.map((d: { msg?: string }) => d.msg ?? String(d)).join(', ')
+  }
+  return fallback
+}

--- a/frontend/src/pages/CategoriasPage.tsx
+++ b/frontend/src/pages/CategoriasPage.tsx
@@ -1,0 +1,347 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Plus, Pencil, Trash2, Tag } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  useCategorias,
+  useCreateCategoria,
+  useUpdateCategoria,
+  useDeleteCategoria,
+} from '@/hooks/useCategorias'
+import { getApiErrorMessage } from '@/lib/apiError'
+import type { CategoriaResponse } from '@/types/transacciones'
+
+interface CategoriaFormData {
+  nombre: string
+  tipo: 'ingreso' | 'egreso' | 'ambos'
+  icono: string
+}
+
+function SkeletonRow(): JSX.Element {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-b border-border last:border-0 animate-pulse">
+      <div className="flex items-center gap-3">
+        <Skeleton className="w-7 h-7 rounded-full" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+      <Skeleton className="h-5 w-16 rounded-full" />
+    </div>
+  )
+}
+
+interface CategoriaModalProps {
+  categoriaEditando: CategoriaResponse | null
+  isLoading: boolean
+  onClose: () => void
+  onSubmit: (data: CategoriaFormData) => Promise<void>
+}
+
+function CategoriaModal({
+  categoriaEditando,
+  isLoading,
+  onClose,
+  onSubmit,
+}: CategoriaModalProps): JSX.Element {
+  const { t } = useTranslation()
+  const [nombre, setNombre] = useState(categoriaEditando?.nombre ?? '')
+  const [tipo, setTipo] = useState<'ingreso' | 'egreso' | 'ambos'>(
+    categoriaEditando?.tipo ?? 'egreso'
+  )
+  const [icono, setIcono] = useState(categoriaEditando?.icono ?? '')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault()
+    if (!nombre.trim()) {
+      setError('El nombre es requerido')
+      return
+    }
+    setError(null)
+    await onSubmit({ nombre: nombre.trim(), tipo, icono: icono.trim() })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={categoriaEditando ? t('categorias.editarTitulo') : t('categorias.nueva')}
+    >
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden="true" />
+      <div className="relative bg-[var(--surface)] rounded-card shadow-card-hover w-full max-w-md">
+        <div className="flex items-center justify-between p-6 border-b border-border">
+          <h2 className="text-lg font-bold text-[var(--text-primary)]">
+            {categoriaEditando ? t('categorias.editarTitulo') : t('categorias.nueva')}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+            aria-label="Cerrar"
+          >
+            <span className="text-xl leading-none">&times;</span>
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-6 flex flex-col gap-4">
+          <Input
+            label={t('categorias.nombre')}
+            value={nombre}
+            onChange={(e) => setNombre(e.target.value)}
+            placeholder="Ej: Alimentacion"
+            required
+            autoFocus
+          />
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-[var(--text-primary)]">
+              {t('categorias.tipo')}
+            </label>
+            <select
+              value={tipo}
+              onChange={(e) => setTipo(e.target.value as 'ingreso' | 'egreso' | 'ambos')}
+              disabled={!!categoriaEditando}
+              className="finza-input w-full disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              <option value="ingreso">{t('categorias.ingreso')}</option>
+              <option value="egreso">{t('categorias.egreso')}</option>
+              <option value="ambos">{t('categorias.ambos')}</option>
+            </select>
+          </div>
+          <Input
+            label={t('categorias.icono')}
+            value={icono}
+            onChange={(e) => setIcono(e.target.value)}
+            placeholder="🎯"
+            maxLength={2}
+          />
+          {error && (
+            <p className="text-xs text-alert-red bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+              {error}
+            </p>
+          )}
+          <div className="flex gap-3 justify-end mt-2">
+            <Button type="button" variant="secondary" size="md" onClick={onClose}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" variant="default" size="md" isLoading={isLoading}>
+              {categoriaEditando ? t('common.save') : t('common.create')}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function TipoBadge({ tipo }: { tipo: 'ingreso' | 'egreso' | 'ambos' }): JSX.Element {
+  const { t } = useTranslation()
+  const variantMap = {
+    ingreso: 'success',
+    egreso: 'danger',
+    ambos: 'info',
+  } as const
+  return (
+    <Badge variant={variantMap[tipo]}>
+      {t(`categorias.${tipo}`)}
+    </Badge>
+  )
+}
+
+export function CategoriasPage(): JSX.Element {
+  const { t } = useTranslation()
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [categoriaEditando, setCategoriaEditando] = useState<CategoriaResponse | null>(null)
+
+  const { data: categorias = [], isLoading, isError } = useCategorias()
+  const createCategoria = useCreateCategoria()
+  const updateCategoria = useUpdateCategoria()
+  const deleteCategoria = useDeleteCategoria()
+
+  const categoriasSistema = categorias.filter((c) => c.es_sistema)
+  const categoriasPersonalizadas = categorias.filter((c) => !c.es_sistema)
+
+  const handleOpenCreate = (): void => {
+    setCategoriaEditando(null)
+    setIsModalOpen(true)
+  }
+
+  const handleOpenEdit = (cat: CategoriaResponse): void => {
+    setCategoriaEditando(cat)
+    setIsModalOpen(true)
+  }
+
+  const handleCloseModal = (): void => {
+    setIsModalOpen(false)
+    setCategoriaEditando(null)
+  }
+
+  const handleSubmit = async (data: CategoriaFormData): Promise<void> => {
+    try {
+      if (categoriaEditando) {
+        await updateCategoria.mutateAsync({
+          id: categoriaEditando.id,
+          nombre: data.nombre,
+          icono: data.icono || undefined,
+        })
+        toast.success(t('categorias.updated'))
+      } else {
+        await createCategoria.mutateAsync({
+          nombre: data.nombre,
+          tipo: data.tipo,
+          icono: data.icono || undefined,
+        })
+        toast.success(t('categorias.created'))
+      }
+      handleCloseModal()
+    } catch (error) {
+      toast.error(getApiErrorMessage(error))
+    }
+  }
+
+  const handleDelete = async (cat: CategoriaResponse): Promise<void> => {
+    if (window.confirm(t('categorias.deleteConfirm'))) {
+      try {
+        await deleteCategoria.mutateAsync(cat.id)
+        toast.success(t('categorias.deleted'))
+      } catch (error) {
+        toast.error(getApiErrorMessage(error))
+      }
+    }
+  }
+
+  const isPending = createCategoria.isPending || updateCategoria.isPending
+
+  return (
+    <div className="animate-fade-in">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <p className="text-[var(--text-muted)] text-sm">
+          {t('categorias.subtitle')}
+        </p>
+        <Button onClick={handleOpenCreate} variant="default" size="md">
+          <Plus size={16} />
+          {t('categorias.nueva')}
+        </Button>
+      </div>
+
+      {/* Error state */}
+      {isError && (
+        <p className="text-sm text-[var(--text-muted)] text-center py-4 mb-4">
+          El servidor no esta disponible. Las categorias se mostraran cuando el backend responda.
+        </p>
+      )}
+
+      {/* Seccion: Sistema */}
+      {!isError && (
+        <section className="mb-8" aria-label="Categorias del sistema">
+          <h2 className="text-sm font-semibold text-[var(--text-muted)] uppercase tracking-wide mb-3">
+            {t('categorias.sistema')}
+          </h2>
+          <div className="finza-card p-0 overflow-hidden">
+            {isLoading && (
+              <>
+                <SkeletonRow />
+                <SkeletonRow />
+                <SkeletonRow />
+              </>
+            )}
+            {!isLoading && categoriasSistema.map((cat) => (
+              <div
+                key={cat.id}
+                className="flex items-center justify-between px-4 py-3 border-b border-border last:border-0"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-7 h-7 rounded-full bg-surface-raised flex items-center justify-center text-sm">
+                    {cat.icono ? cat.icono : <Tag size={14} className="text-[var(--text-muted)]" />}
+                  </div>
+                  <span className="text-sm text-[var(--text-primary)]">{cat.nombre}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <TipoBadge tipo={cat.tipo} />
+                  <Badge variant="neutral">{t('categorias.sistema')}</Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Seccion: Personalizadas */}
+      {!isError && (
+        <section aria-label="Categorias personalizadas">
+          <h2 className="text-sm font-semibold text-[var(--text-muted)] uppercase tracking-wide mb-3">
+            {t('categorias.personalizada')}
+          </h2>
+          <div className="finza-card p-0 overflow-hidden">
+            {isLoading && (
+              <>
+                <SkeletonRow />
+                <SkeletonRow />
+              </>
+            )}
+            {!isLoading && categoriasPersonalizadas.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-12 text-center px-4">
+                <Tag size={40} className="text-[var(--text-muted)] opacity-30 mb-3" aria-hidden="true" />
+                <p className="text-sm font-medium text-[var(--text-primary)]">
+                  {t('categorias.noCategorias')}
+                </p>
+                <p className="text-xs text-[var(--text-muted)] mt-1 mb-4">
+                  {t('categorias.noCategoriasDesc')}
+                </p>
+                <Button onClick={handleOpenCreate} size="md">
+                  <Plus size={16} />
+                  {t('categorias.nueva')}
+                </Button>
+              </div>
+            )}
+            {!isLoading && categoriasPersonalizadas.map((cat) => (
+              <div
+                key={cat.id}
+                className="flex items-center justify-between px-4 py-3 border-b border-border last:border-0"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-7 h-7 rounded-full bg-surface-raised flex items-center justify-center text-sm">
+                    {cat.icono ? cat.icono : <Tag size={14} className="text-[var(--text-muted)]" />}
+                  </div>
+                  <span className="text-sm text-[var(--text-primary)]">{cat.nombre}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <TipoBadge tipo={cat.tipo} />
+                  <button
+                    type="button"
+                    onClick={() => handleOpenEdit(cat)}
+                    aria-label={`Editar ${cat.nombre}`}
+                    className="p-1.5 rounded text-[var(--text-muted)] hover:text-finza-blue hover:bg-blue-50 transition-colors"
+                  >
+                    <Pencil size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(cat)}
+                    aria-label={`Eliminar ${cat.nombre}`}
+                    className="p-1.5 rounded text-[var(--text-muted)] hover:text-alert-red hover:bg-red-50 transition-colors"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Modal crear/editar */}
+      {isModalOpen && (
+        <CategoriaModal
+          categoriaEditando={categoriaEditando}
+          isLoading={isPending}
+          onClose={handleCloseModal}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/MetasPage.tsx
+++ b/frontend/src/pages/MetasPage.tsx
@@ -11,6 +11,7 @@ import { MetaDetail } from '@/features/metas/components/MetaDetail'
 import type { MetaFormData } from '@/features/metas/components/MetaForm'
 import { useMetas, useCreateMeta, useUpdateMeta, useDeleteMeta } from '@/hooks/useMetas'
 import type { MetaAhorro } from '@/types/meta_ahorro'
+import { getApiErrorMessage } from '@/lib/apiError'
 
 function SkeletonCard(): JSX.Element {
   return (
@@ -76,8 +77,8 @@ export function MetasPage(): JSX.Element {
       })
       setIsModalOpen(false)
       toast.success(t('metas.created'))
-    } catch {
-      toast.error(t('common.error'))
+    } catch (error) {
+      toast.error(getApiErrorMessage(error))
     }
   }
 
@@ -96,8 +97,8 @@ export function MetasPage(): JSX.Element {
       })
       setMetaEditando(null)
       toast.success(t('metas.updated'))
-    } catch {
-      toast.error(t('common.error'))
+    } catch (error) {
+      toast.error(getApiErrorMessage(error))
     }
   }
 
@@ -108,8 +109,8 @@ export function MetasPage(): JSX.Element {
         setDetailId(null)
         setMetaSeleccionada(null)
         toast.success(t('metas.deleted'))
-      } catch {
-        toast.error(t('common.error'))
+      } catch (error) {
+        toast.error(getApiErrorMessage(error))
       }
     }
   }

--- a/frontend/src/pages/PresupuestosPage.tsx
+++ b/frontend/src/pages/PresupuestosPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Plus, Target } from 'lucide-react'
 import axios from 'axios'
 import { toast } from 'sonner'
+import { getApiErrorMessage } from '@/lib/apiError'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PresupuestoCard } from '@/features/presupuestos/components/PresupuestoCard'
@@ -143,10 +144,10 @@ export function PresupuestosPage(): JSX.Element {
       toast.success(t('presupuestos.created'))
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 409) {
-        setFormError('Ya existe un presupuesto para esta categoria en este mes')
+        setFormError(getApiErrorMessage(error, 'Ya existe un presupuesto para esta categoria'))
       } else {
-        setFormError('Error al crear el presupuesto. Intenta de nuevo.')
-        toast.error(t('common.error'))
+        setFormError(getApiErrorMessage(error, 'Error al crear el presupuesto. Intenta de nuevo.'))
+        toast.error(getApiErrorMessage(error))
       }
     }
   }
@@ -161,9 +162,9 @@ export function PresupuestosPage(): JSX.Element {
       })
       handleCloseEdit()
       toast.success(t('presupuestos.updated'))
-    } catch (_error) {
-      setFormError('Error al actualizar el presupuesto. Intenta de nuevo.')
-      toast.error(t('common.error'))
+    } catch (error) {
+      setFormError(getApiErrorMessage(error, 'Error al actualizar el presupuesto. Intenta de nuevo.'))
+      toast.error(getApiErrorMessage(error))
     }
   }
 
@@ -174,8 +175,8 @@ export function PresupuestosPage(): JSX.Element {
         await deletePresupuesto.mutateAsync(editingEstado.id)
         handleCloseEdit()
         toast.success(t('presupuestos.deleted'))
-      } catch {
-        toast.error(t('common.error'))
+      } catch (error) {
+        toast.error(getApiErrorMessage(error))
       }
     }
   }

--- a/frontend/src/pages/__tests__/CategoriasPage.test.tsx
+++ b/frontend/src/pages/__tests__/CategoriasPage.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CategoriasPage } from '@/pages/CategoriasPage'
+import type { CategoriaResponse } from '@/types/transacciones'
+
+vi.mock('@/hooks/useCategorias', () => ({
+  useCategorias: vi.fn(),
+  useCreateCategoria: vi.fn(),
+  useUpdateCategoria: vi.fn(),
+  useDeleteCategoria: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import {
+  useCategorias,
+  useCreateCategoria,
+  useUpdateCategoria,
+  useDeleteCategoria,
+} from '@/hooks/useCategorias'
+
+const mockCategoriasSistema: CategoriaResponse[] = [
+  { id: 'sys-1', nombre: 'Salario', tipo: 'ingreso', icono: '💼', color: null, es_sistema: true },
+  { id: 'sys-2', nombre: 'Alimentacion', tipo: 'egreso', icono: '🍔', color: null, es_sistema: true },
+]
+
+const mockCategoriasPersonalizadas: CategoriaResponse[] = [
+  { id: 'usr-1', nombre: 'Mascota', tipo: 'egreso', icono: '🐾', color: null, es_sistema: false },
+]
+
+const mockAllCategorias = [...mockCategoriasSistema, ...mockCategoriasPersonalizadas]
+
+function setupMocks({
+  data = mockAllCategorias,
+  isLoading = false,
+  isError = false,
+}: {
+  data?: CategoriaResponse[]
+  isLoading?: boolean
+  isError?: boolean
+} = {}) {
+  vi.mocked(useCategorias).mockReturnValue({
+    data,
+    isLoading,
+    isError,
+    isPending: isLoading,
+    isSuccess: !isLoading && !isError,
+    error: null,
+  } as ReturnType<typeof useCategorias>)
+
+  vi.mocked(useCreateCategoria).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  } as unknown as ReturnType<typeof useCreateCategoria>)
+
+  vi.mocked(useUpdateCategoria).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateCategoria>)
+
+  vi.mocked(useDeleteCategoria).mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
+  } as unknown as ReturnType<typeof useDeleteCategoria>)
+}
+
+describe('CategoriasPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders the page subtitle', () => {
+    render(<CategoriasPage />)
+    expect(
+      screen.getByText('Administra tus categorias de ingresos y egresos')
+    ).toBeInTheDocument()
+  })
+
+  it('renders the nueva categoria button', () => {
+    render(<CategoriasPage />)
+    const buttons = screen.getAllByRole('button', { name: /nueva categoria/i })
+    expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  it('shows skeleton rows when loading', () => {
+    setupMocks({ isLoading: true, data: [] })
+    render(<CategoriasPage />)
+    const pulsingElements = document.querySelectorAll('.animate-pulse')
+    expect(pulsingElements.length).toBeGreaterThan(0)
+  })
+
+  it('shows sistema badge for system categories', () => {
+    render(<CategoriasPage />)
+    // Each system category has a Badge with 'Sistema' text (span elements)
+    // The h2 heading also contains 'Sistema', so we look for span badges specifically
+    const sistemaBadges = document.querySelectorAll('span.rounded-full')
+    const sistemaBadgeTexts = Array.from(sistemaBadges).filter(
+      (el) => el.textContent?.trim() === 'Sistema'
+    )
+    expect(sistemaBadgeTexts.length).toBe(mockCategoriasSistema.length)
+  })
+
+  it('shows edit button only for non-sistema categories', () => {
+    render(<CategoriasPage />)
+    const editButtons = screen.getAllByLabelText(/Editar/)
+    // Only personalizada categories should have edit buttons
+    expect(editButtons).toHaveLength(mockCategoriasPersonalizadas.length)
+  })
+
+  it('shows delete button only for non-sistema categories', () => {
+    render(<CategoriasPage />)
+    const deleteButtons = screen.getAllByLabelText(/Eliminar/)
+    expect(deleteButtons).toHaveLength(mockCategoriasPersonalizadas.length)
+  })
+
+  it('shows empty state when no custom categories exist', () => {
+    setupMocks({ data: mockCategoriasSistema })
+    render(<CategoriasPage />)
+    expect(screen.getByText('Sin categorias personalizadas')).toBeInTheDocument()
+    expect(screen.getByText('Crea tu primera categoria personalizada')).toBeInTheDocument()
+  })
+
+  it('renders system category names', () => {
+    render(<CategoriasPage />)
+    expect(screen.getByText('Salario')).toBeInTheDocument()
+    expect(screen.getByText('Alimentacion')).toBeInTheDocument()
+  })
+
+  it('renders custom category names', () => {
+    render(<CategoriasPage />)
+    expect(screen.getByText('Mascota')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Add getApiErrorMessage utility (src/lib/apiError.ts) to extract FastAPI error detail from axios errors
- Fix all catch blocks in MetasPage and PresupuestosPage to show descriptive error messages
- Add try/catch + success/error toasts to PrestamoDetail handleRegistrarPago
- Fix PresupuestoForm category select: loading/empty states
- Add useCreateCategoria, useUpdateCategoria, useDeleteCategoria mutations to useCategorias hook
- Add CategoriasPage with full CRUD (Sistema section read-only, Personalizadas with edit/delete)
- Add /categorias route to App.tsx
- Add Categorias nav item to Sidebar (Tag icon)
- Add i18n keys: nav.categorias, prestamos.pagoRegistrado, full categorias namespace (es + en)

## Test plan
- [ ] Toast errors show descriptive messages from API (not just 'Error')
- [ ] Presupuestos/Metas creation shows backend error when it fails
- [ ] Registrar pago en prestamos muestra toast de exito
- [ ] PresupuestoForm categorias: loading state + empty state visible
- [ ] /categorias visible en sidebar con icono Tag
- [ ] CategoriasPage: secciones Sistema y Personalizadas renderizadas
- [ ] CategoriasPage: crear categoria personalizada
- [ ] CategoriasPage: editar categoria personalizada (tipo disabled al editar)
- [ ] CategoriasPage: eliminar con confirmacion
- [ ] CategoriasPage: categorias sistema sin botones editar/eliminar
- [ ] vitest --run: 27 test files, 249 tests, all green

## Tests
- 9 nuevos tests en CategoriasPage.test.tsx
- 249 tests totales, 27 archivos, todos passing

Generated with Claude Code