### PR TITLE
feat(backend): Wave 8 Fase 2 — fondo emergencia, impulso, suscripciones, profiles

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter
 
 from app.api.v1.routes.categorias import router as categorias_router
+from app.api.v1.routes.fondo_emergencia import router as fondo_emergencia_router
+from app.api.v1.routes.impulso import router as impulso_router
+from app.api.v1.routes.profiles import router as profiles_router
+from app.api.v1.routes.suscripciones import router as suscripciones_router
 from app.api.v1.routes.dashboard import router as dashboard_router
 from app.api.v1.routes.egresos import router as egresos_router
 from app.api.v1.routes.health import router as health_router
@@ -24,3 +28,7 @@ api_router.include_router(presupuestos_router)
 api_router.include_router(score_router)
 api_router.include_router(prediccion_router)
 api_router.include_router(notificaciones_router)
+api_router.include_router(fondo_emergencia_router)
+api_router.include_router(impulso_router)
+api_router.include_router(suscripciones_router)
+api_router.include_router(profiles_router)

--- a/backend/app/api/v1/routes/fondo_emergencia.py
+++ b/backend/app/api/v1/routes/fondo_emergencia.py
@@ -1,0 +1,59 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.fondo_emergencia import (
+    FondoEmergenciaCreate,
+    FondoEmergenciaResponse,
+    FondoEmergenciaUpdate,
+    MontoRequest,
+)
+from app.services import fondo_emergencia as svc
+
+router = APIRouter(prefix="/fondo-emergencia", tags=["fondo-emergencia"])
+
+
+@router.get("", response_model=FondoEmergenciaResponse)
+async def get_fondo(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    fondo = svc.get_or_none(user_jwt=token, user_id=current_user["user_id"])
+    if fondo is None:
+        raise HTTPException(status_code=404, detail="Fondo de emergencia no encontrado.")
+    return fondo
+
+
+@router.post("", response_model=FondoEmergenciaResponse, status_code=201)
+async def create_fondo(
+    data: FondoEmergenciaCreate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.create_fondo(user_jwt=token, user_id=current_user["user_id"], data=data)
+
+
+@router.patch("", response_model=FondoEmergenciaResponse)
+async def update_fondo(
+    data: FondoEmergenciaUpdate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.update_fondo(user_jwt=token, user_id=current_user["user_id"], data=data)
+
+
+@router.post("/depositar", response_model=FondoEmergenciaResponse)
+async def depositar(
+    body: MontoRequest,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.depositar(user_jwt=token, user_id=current_user["user_id"], monto=body.monto)
+
+
+@router.post("/retirar", response_model=FondoEmergenciaResponse)
+async def retirar(
+    body: MontoRequest,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.retirar(user_jwt=token, user_id=current_user["user_id"], monto=body.monto)

--- a/backend/app/api/v1/routes/impulso.py
+++ b/backend/app/api/v1/routes/impulso.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, Query
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.impulso import (
+    ImpulsoClasificarRequest,
+    ImpulsoEvalResponse,
+    ImpulsoResumenResponse,
+)
+from app.services import impulso as svc
+
+router = APIRouter(tags=["impulso"])
+
+
+@router.post("/egresos/evaluar-impulsos", response_model=ImpulsoEvalResponse)
+async def evaluar_impulsos(
+    mes: int = Query(..., ge=1, le=12),
+    year: int = Query(..., ge=2000),
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.evaluar_impulsos(
+        user_jwt=token, user_id=current_user["user_id"], mes=mes, year=year
+    )
+
+
+@router.patch("/egresos/{egreso_id}/clasificar-impulso")
+async def clasificar_impulso(
+    egreso_id: str,
+    body: ImpulsoClasificarRequest,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.clasificar_impulso(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        egreso_id=egreso_id,
+        es_impulso=body.es_impulso,
+    )
+
+
+@router.get("/egresos/resumen-impulso", response_model=ImpulsoResumenResponse)
+async def get_resumen_impulso(
+    mes: int = Query(..., ge=1, le=12),
+    year: int = Query(..., ge=2000),
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.get_resumen_impulso(
+        user_jwt=token, user_id=current_user["user_id"], mes=mes, year=year
+    )

--- a/backend/app/api/v1/routes/profiles.py
+++ b/backend/app/api/v1/routes/profiles.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.profile import ProfileResponse, ProfileUpdate
+from app.services import profiles as svc
+
+router = APIRouter(prefix="/profiles", tags=["profiles"])
+
+
+@router.get("/me", response_model=ProfileResponse)
+async def get_my_profile(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.get_or_create_profile(user_jwt=token, user_id=current_user["user_id"])
+
+
+@router.patch("/me", response_model=ProfileResponse)
+async def update_my_profile(
+    data: ProfileUpdate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.update_profile(user_jwt=token, user_id=current_user["user_id"], data=data)

--- a/backend/app/api/v1/routes/suscripciones.py
+++ b/backend/app/api/v1/routes/suscripciones.py
@@ -1,0 +1,83 @@
+from fastapi import APIRouter, Depends
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.suscripcion import (
+    ConfirmarDetectadasRequest,
+    SuscripcionCreate,
+    SuscripcionResumenResponse,
+    SuscripcionResponse,
+    SuscripcionUpdate,
+)
+from app.services import suscripciones as svc
+
+router = APIRouter(prefix="/suscripciones", tags=["suscripciones"])
+
+
+@router.get("", response_model=list[SuscripcionResponse])
+async def list_suscripciones(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.list_suscripciones(user_jwt=token, user_id=current_user["user_id"])
+
+
+@router.get("/resumen", response_model=SuscripcionResumenResponse)
+async def get_resumen(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.get_resumen(user_jwt=token, user_id=current_user["user_id"])
+
+
+@router.post("", response_model=SuscripcionResponse, status_code=201)
+async def create_suscripcion(
+    data: SuscripcionCreate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.create_suscripcion(user_jwt=token, user_id=current_user["user_id"], data=data)
+
+
+@router.put("/{suscripcion_id}", response_model=SuscripcionResponse)
+async def update_suscripcion(
+    suscripcion_id: str,
+    data: SuscripcionUpdate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.update_suscripcion(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        suscripcion_id=suscripcion_id,
+        data=data,
+    )
+
+
+@router.delete("/{suscripcion_id}", status_code=204)
+async def delete_suscripcion(
+    suscripcion_id: str,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    svc.delete_suscripcion(
+        user_jwt=token, user_id=current_user["user_id"], suscripcion_id=suscripcion_id
+    )
+
+
+@router.post("/detectar", response_model=list[SuscripcionResponse])
+async def detectar_suscripciones(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.detectar_suscripciones(user_jwt=token, user_id=current_user["user_id"])
+
+
+@router.post("/confirmar-detectadas", response_model=list[SuscripcionResponse])
+async def confirmar_detectadas(
+    body: ConfirmarDetectadasRequest,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    # body.ids are candidate dicts simplified — build minimal dicts
+    candidatos = [{"id": cid, "nombre": cid, "monto": 0, "frecuencia": "mensual", "moneda": "DOP"} for cid in body.ids]
+    return svc.confirmar_detectadas(user_jwt=token, user_id=current_user["user_id"], candidatos=candidatos)

--- a/backend/app/schemas/fondo_emergencia.py
+++ b/backend/app/schemas/fondo_emergencia.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class FondoEmergenciaCreate(BaseModel):
+    monto_actual: float = Field(default=0, ge=0)
+    meta_meses: int = Field(default=3)
+    notas: Optional[str] = None
+
+
+class FondoEmergenciaUpdate(BaseModel):
+    monto_actual: Optional[float] = Field(None, ge=0)
+    meta_meses: Optional[int] = None
+    notas: Optional[str] = None
+
+
+class MontoRequest(BaseModel):
+    monto: float = Field(gt=0)
+
+
+class FondoEmergenciaResponse(BaseModel):
+    id: str
+    user_id: str
+    monto_actual: float
+    meta_meses: int
+    meta_calculada: Optional[float]
+    porcentaje: float
+    notas: Optional[str]
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/impulso.py
+++ b/backend/app/schemas/impulso.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class ImpulsoEvalResponse(BaseModel):
+    evaluados: int
+    marcados_impulso: int
+
+
+class ImpulsoClasificarRequest(BaseModel):
+    es_impulso: bool
+
+
+class ImpulsoResumenResponse(BaseModel):
+    cantidad_impulso: int
+    total_impulso: float
+    porcentaje_del_total: float

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ProfileUpdate(BaseModel):
+    salario_mensual_neto: Optional[float] = Field(None, gt=0)
+    mostrar_horas_trabajo: Optional[bool] = None
+
+
+class ProfileResponse(BaseModel):
+    user_id: str
+    salario_mensual_neto: Optional[float]
+    mostrar_horas_trabajo: bool
+    horas_por_peso: Optional[float]
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/suscripcion.py
+++ b/backend/app/schemas/suscripcion.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class SuscripcionCreate(BaseModel):
+    nombre: str
+    monto: float = Field(gt=0)
+    frecuencia: str
+    moneda: str = "DOP"
+    categoria_id: Optional[str] = None
+    fecha_proximo_cobro: Optional[str] = None
+    notas: Optional[str] = None
+
+
+class SuscripcionUpdate(BaseModel):
+    nombre: Optional[str] = None
+    monto: Optional[float] = Field(None, gt=0)
+    frecuencia: Optional[str] = None
+    moneda: Optional[str] = None
+    categoria_id: Optional[str] = None
+    fecha_proximo_cobro: Optional[str] = None
+    activa: Optional[bool] = None
+    notas: Optional[str] = None
+
+
+class ConfirmarDetectadasRequest(BaseModel):
+    ids: list[str]
+
+
+class SuscripcionResponse(BaseModel):
+    id: str
+    nombre: str
+    monto: float
+    monto_mensual: float
+    frecuencia: str
+    moneda: str
+    activa: bool
+    auto_detectada: bool
+    fecha_proximo_cobro: Optional[str]
+    notas: Optional[str]
+
+    model_config = {"from_attributes": True}
+
+
+class SuscripcionResumenResponse(BaseModel):
+    total_mensual: float
+    total_anual: float
+    cantidad_activas: int
+    suscripciones: list[SuscripcionResponse]

--- a/backend/app/services/fondo_emergencia.py
+++ b/backend/app/services/fondo_emergencia.py
@@ -1,0 +1,126 @@
+from datetime import date
+
+from fastapi import HTTPException
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.schemas.fondo_emergencia import FondoEmergenciaCreate, FondoEmergenciaUpdate
+from app.services.base import _handle_api_error
+
+
+def _calc_meta(client, user_id: str, meta_meses: int) -> float:
+    """Average monthly expenses over last 3 months * meta_meses."""
+    today = date.today()
+    meses: list[tuple[int, int]] = []
+    for i in range(3):
+        m = today.month - i
+        y = today.year
+        if m <= 0:
+            m += 12
+            y -= 1
+        meses.append((y, m))
+
+    try:
+        r = (
+            client.table("egresos")
+            .select("monto,mes,year")
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+        return 0.0
+
+    egresos = r.data or []
+    totales: dict[tuple[int, int], float] = {}
+    for e in egresos:
+        key = (int(e.get("year", 0)), int(e.get("mes", 0)))
+        if key in dict.fromkeys(meses):
+            totales[key] = totales.get(key, 0.0) + float(e["monto"])
+
+    if not totales:
+        return 0.0
+
+    promedio = sum(totales.values()) / len(meses)
+    return promedio * meta_meses
+
+
+def _enrich(row: dict, client, user_id: str) -> dict:
+    meta_calculada = _calc_meta(client, user_id, row["meta_meses"])
+    monto_actual = float(row["monto_actual"])
+    porcentaje = min(monto_actual / meta_calculada * 100, 100.0) if meta_calculada > 0 else 0.0
+    return {
+        **row,
+        "monto_actual": monto_actual,
+        "meta_calculada": meta_calculada if meta_calculada > 0 else None,
+        "porcentaje": round(porcentaje, 2),
+    }
+
+
+def get_or_none(user_jwt: str, user_id: str) -> dict | None:
+    client = get_user_client(user_jwt)
+    try:
+        r = (
+            client.table("fondo_emergencia")
+            .select("*")
+            .eq("user_id", user_id)
+            .maybe_single()
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    if not r.data:
+        return None
+    return _enrich(r.data, client, user_id)
+
+
+def create_fondo(user_jwt: str, user_id: str, data: FondoEmergenciaCreate) -> dict:
+    client = get_user_client(user_jwt)
+    payload = {
+        "user_id": user_id,
+        "monto_actual": str(data.monto_actual),
+        "meta_meses": data.meta_meses,
+        "notas": data.notas,
+    }
+    try:
+        r = client.table("fondo_emergencia").insert(payload).execute()
+    except APIError as e:
+        _handle_api_error(e)
+    return _enrich(r.data[0], client, user_id)
+
+
+def update_fondo(user_jwt: str, user_id: str, data: FondoEmergenciaUpdate) -> dict:
+    client = get_user_client(user_jwt)
+    payload = {k: v for k, v in data.model_dump().items() if v is not None}
+    if "monto_actual" in payload:
+        payload["monto_actual"] = str(payload["monto_actual"])
+    if not payload:
+        raise HTTPException(status_code=422, detail="No fields to update.")
+    try:
+        r = (
+            client.table("fondo_emergencia")
+            .update(payload)
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    if not r.data:
+        raise HTTPException(status_code=404, detail="Fondo de emergencia no encontrado.")
+    return _enrich(r.data[0], client, user_id)
+
+
+def depositar(user_jwt: str, user_id: str, monto: float) -> dict:
+    fondo = get_or_none(user_jwt, user_id)
+    if fondo is None:
+        raise HTTPException(status_code=404, detail="Fondo de emergencia no encontrado.")
+    nuevo_monto = fondo["monto_actual"] + monto
+    return update_fondo(user_jwt, user_id, FondoEmergenciaUpdate(monto_actual=nuevo_monto))
+
+
+def retirar(user_jwt: str, user_id: str, monto: float) -> dict:
+    fondo = get_or_none(user_jwt, user_id)
+    if fondo is None:
+        raise HTTPException(status_code=404, detail="Fondo de emergencia no encontrado.")
+    nuevo_monto = max(0.0, fondo["monto_actual"] - monto)
+    return update_fondo(user_jwt, user_id, FondoEmergenciaUpdate(monto_actual=nuevo_monto))

--- a/backend/app/services/impulso.py
+++ b/backend/app/services/impulso.py
@@ -1,0 +1,151 @@
+from fastapi import HTTPException
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.services.base import _handle_api_error
+
+
+def evaluar_impulsos(user_jwt: str, user_id: str, mes: int, year: int) -> dict:
+    """Detect impulsive purchases using 2 criteria and mark egresos accordingly."""
+    client = get_user_client(user_jwt)
+    try:
+        egresos_r = (
+            client.table("egresos")
+            .select("id,monto,categoria_id,impulso_clasificado")
+            .eq("user_id", user_id)
+            .eq("mes", mes)
+            .eq("year", year)
+            .eq("impulso_clasificado", False)
+            .execute()
+        )
+        presupuestos_r = (
+            client.table("presupuestos")
+            .select("categoria_id,monto_limite")
+            .eq("user_id", user_id)
+            .eq("mes", mes)
+            .eq("year", year)
+            .execute()
+        )
+        historico_r = (
+            client.table("egresos")
+            .select("monto,categoria_id,mes,year")
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+
+    egresos = egresos_r.data or []
+    presupuestos = presupuestos_r.data or []
+    historico = historico_r.data or []
+
+    # Build budget map: categoria_id -> limite
+    budget_map: dict[str, float] = {}
+    for p in presupuestos:
+        budget_map[str(p["categoria_id"])] = float(p["monto_limite"])
+
+    # Build gasto actual por categoria this month
+    gasto_mes: dict[str, float] = {}
+    for e in historico:
+        if int(e.get("mes", 0)) == mes and int(e.get("year", 0)) == year:
+            cat = str(e.get("categoria_id", ""))
+            gasto_mes[cat] = gasto_mes.get(cat, 0.0) + float(e["monto"])
+
+    # Build historical average per categoria (last 3 months excluding current)
+    from datetime import date
+    today = date.today()
+    meses_hist: list[tuple[int, int]] = []
+    for i in range(1, 4):
+        m = today.month - i
+        y = today.year
+        if m <= 0:
+            m += 12
+            y -= 1
+        meses_hist.append((y, m))
+
+    hist_totals: dict[str, list[float]] = {}
+    for e in historico:
+        key = (int(e.get("year", 0)), int(e.get("mes", 0)))
+        if key in meses_hist:
+            cat = str(e.get("categoria_id", ""))
+            hist_totals.setdefault(cat, []).append(float(e["monto"]))
+
+    hist_avg: dict[str, float] = {
+        cat: sum(amounts) / len(amounts) for cat, amounts in hist_totals.items()
+    }
+
+    evaluados = 0
+    marcados = 0
+
+    for egreso in egresos:
+        eid = str(egreso["id"])
+        cat = str(egreso.get("categoria_id", ""))
+        monto = float(egreso["monto"])
+        evaluados += 1
+        es_impulso = False
+
+        # Criterion 1: category exceeded budget
+        if cat in budget_map and gasto_mes.get(cat, 0.0) > budget_map[cat]:
+            es_impulso = True
+
+        # Criterion 2: monto > 2x historical average for category
+        if not es_impulso and cat in hist_avg and hist_avg[cat] > 0:
+            if monto > 2 * hist_avg[cat]:
+                es_impulso = True
+
+        try:
+            client.table("egresos").update({
+                "is_impulso": es_impulso,
+                "impulso_clasificado": not es_impulso,  # auto-discard if not impulso
+            }).eq("id", eid).execute()
+        except APIError as e:
+            _handle_api_error(e)
+
+        if es_impulso:
+            marcados += 1
+
+    return {"evaluados": evaluados, "marcados_impulso": marcados}
+
+
+def clasificar_impulso(user_jwt: str, user_id: str, egreso_id: str, es_impulso: bool) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        r = (
+            client.table("egresos")
+            .update({"is_impulso": es_impulso, "impulso_clasificado": True})
+            .eq("id", egreso_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    if not r.data:
+        raise HTTPException(status_code=404, detail="Egreso no encontrado.")
+    return r.data[0]
+
+
+def get_resumen_impulso(user_jwt: str, user_id: str, mes: int, year: int) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        egresos_r = (
+            client.table("egresos")
+            .select("monto,is_impulso")
+            .eq("user_id", user_id)
+            .eq("mes", mes)
+            .eq("year", year)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+
+    egresos = egresos_r.data or []
+    total_mes = sum(float(e["monto"]) for e in egresos)
+    impulsos = [e for e in egresos if e.get("is_impulso") is True]
+    total_impulso = sum(float(e["monto"]) for e in impulsos)
+    porcentaje = (total_impulso / total_mes * 100) if total_mes > 0 else 0.0
+
+    return {
+        "cantidad_impulso": len(impulsos),
+        "total_impulso": round(total_impulso, 2),
+        "porcentaje_del_total": round(porcentaje, 2),
+    }

--- a/backend/app/services/profiles.py
+++ b/backend/app/services/profiles.py
@@ -1,0 +1,65 @@
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.schemas.profile import ProfileUpdate
+from app.services.base import _handle_api_error
+
+
+def _enrich(row: dict) -> dict:
+    salario = row.get("salario_mensual_neto")
+    horas_por_peso = round(160.0 / float(salario), 6) if salario and float(salario) > 0 else None
+    return {
+        **row,
+        "salario_mensual_neto": float(salario) if salario is not None else None,
+        "horas_por_peso": horas_por_peso,
+    }
+
+
+def get_or_create_profile(user_jwt: str, user_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        r = (
+            client.table("profiles")
+            .select("*")
+            .eq("user_id", user_id)
+            .maybe_single()
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+
+    if r.data:
+        return _enrich(r.data)
+
+    # Create default profile
+    try:
+        r2 = (
+            client.table("profiles")
+            .insert({"user_id": user_id})
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+
+    return _enrich(r2.data[0])
+
+
+def update_profile(user_jwt: str, user_id: str, data: ProfileUpdate) -> dict:
+    client = get_user_client(user_jwt)
+    payload = {k: v for k, v in data.model_dump().items() if v is not None}
+    if not payload:
+        return get_or_create_profile(user_jwt, user_id)
+
+    if "salario_mensual_neto" in payload:
+        payload["salario_mensual_neto"] = str(payload["salario_mensual_neto"])
+
+    try:
+        r = (
+            client.table("profiles")
+            .upsert({"user_id": user_id, **payload})
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+
+    return _enrich(r.data[0])

--- a/backend/app/services/suscripciones.py
+++ b/backend/app/services/suscripciones.py
@@ -1,0 +1,200 @@
+from fastapi import HTTPException
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.schemas.suscripcion import SuscripcionCreate, SuscripcionUpdate
+from app.services.base import _handle_api_error
+
+FRECUENCIA_FACTOR: dict[str, float] = {
+    "mensual": 1.0,
+    "anual": 1 / 12,
+    "semanal": 4.33,
+    "trimestral": 1 / 3,
+}
+
+
+def _monto_mensual(monto: float, frecuencia: str) -> float:
+    return round(monto * FRECUENCIA_FACTOR.get(frecuencia, 1.0), 2)
+
+
+def _enrich(row: dict) -> dict:
+    return {
+        **row,
+        "monto": float(row["monto"]),
+        "monto_mensual": _monto_mensual(float(row["monto"]), row["frecuencia"]),
+    }
+
+
+def list_suscripciones(user_jwt: str, user_id: str) -> list[dict]:
+    client = get_user_client(user_jwt)
+    try:
+        r = (
+            client.table("suscripciones")
+            .select("*")
+            .eq("user_id", user_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    return [_enrich(row) for row in (r.data or [])]
+
+
+def get_resumen(user_jwt: str, user_id: str) -> dict:
+    suscripciones = list_suscripciones(user_jwt, user_id)
+    activas = [s for s in suscripciones if s["activa"]]
+    total_mensual = round(sum(s["monto_mensual"] for s in activas), 2)
+    return {
+        "total_mensual": total_mensual,
+        "total_anual": round(total_mensual * 12, 2),
+        "cantidad_activas": len(activas),
+        "suscripciones": activas,
+    }
+
+
+def create_suscripcion(user_jwt: str, user_id: str, data: SuscripcionCreate) -> dict:
+    client = get_user_client(user_jwt)
+    payload = {
+        "user_id": user_id,
+        "nombre": data.nombre,
+        "monto": str(data.monto),
+        "frecuencia": data.frecuencia,
+        "moneda": data.moneda,
+        "categoria_id": str(data.categoria_id) if data.categoria_id else None,
+        "fecha_proximo_cobro": data.fecha_proximo_cobro,
+        "notas": data.notas,
+    }
+    try:
+        r = client.table("suscripciones").insert(payload).execute()
+    except APIError as e:
+        _handle_api_error(e)
+    return _enrich(r.data[0])
+
+
+def update_suscripcion(user_jwt: str, user_id: str, suscripcion_id: str, data: SuscripcionUpdate) -> dict:
+    client = get_user_client(user_jwt)
+    payload = {k: v for k, v in data.model_dump().items() if v is not None}
+    if "monto" in payload:
+        payload["monto"] = str(payload["monto"])
+    if not payload:
+        raise HTTPException(status_code=422, detail="No fields to update.")
+    try:
+        r = (
+            client.table("suscripciones")
+            .update(payload)
+            .eq("id", suscripcion_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    if not r.data:
+        raise HTTPException(status_code=404, detail="Suscripcion no encontrada.")
+    return _enrich(r.data[0])
+
+
+def delete_suscripcion(user_jwt: str, user_id: str, suscripcion_id: str) -> None:
+    client = get_user_client(user_jwt)
+    try:
+        r = (
+            client.table("suscripciones")
+            .delete()
+            .eq("id", suscripcion_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    if not r.data:
+        raise HTTPException(status_code=404, detail="Suscripcion no encontrada.")
+
+
+def detectar_suscripciones(user_jwt: str, user_id: str) -> list[dict]:
+    """Find recurring patterns in last 3 months of egresos (candidates, not created)."""
+    client = get_user_client(user_jwt)
+    from datetime import date
+    today = date.today()
+    meses: list[tuple[int, int]] = []
+    for i in range(3):
+        m = today.month - i
+        y = today.year
+        if m <= 0:
+            m += 12
+            y -= 1
+        meses.append((y, m))
+
+    try:
+        r = (
+            client.table("egresos")
+            .select("descripcion,monto,categoria_id,mes,year")
+            .eq("user_id", user_id)
+            .execute()
+        )
+    except APIError as e:
+        _handle_api_error(e)
+
+    egresos = r.data or []
+    # Group by description
+    from collections import defaultdict
+    by_desc: dict[str, list[dict]] = defaultdict(list)
+    for e in egresos:
+        key = (int(e.get("year", 0)), int(e.get("mes", 0)))
+        if key in meses:
+            desc = str(e.get("descripcion", "")).strip().lower()
+            if desc:
+                by_desc[desc].append(e)
+
+    candidatos = []
+    for desc, items in by_desc.items():
+        # Appears in 2+ different months
+        months_seen = {(int(e.get("year", 0)), int(e.get("mes", 0))) for e in items}
+        if len(months_seen) >= 2:
+            montos = [float(e["monto"]) for e in items]
+            avg = sum(montos) / len(montos)
+            # Check monto consistency (within ±10%)
+            if all(abs(m - avg) / avg <= 0.10 for m in montos):
+                candidatos.append({
+                    "id": f"candidate-{desc[:20]}",
+                    "nombre": items[0].get("descripcion", desc),
+                    "monto": round(avg, 2),
+                    "monto_mensual": round(avg, 2),
+                    "frecuencia": "mensual",
+                    "moneda": "DOP",
+                    "activa": True,
+                    "auto_detectada": True,
+                    "fecha_proximo_cobro": None,
+                    "notas": None,
+                    "categoria_id": items[0].get("categoria_id"),
+                })
+
+    return candidatos
+
+
+def confirmar_detectadas(user_jwt: str, user_id: str, candidatos: list[dict]) -> list[dict]:
+    """Create suscripciones from confirmed candidates."""
+    resultado = []
+    for c in candidatos:
+        data = SuscripcionCreate(
+            nombre=c["nombre"],
+            monto=c["monto"],
+            frecuencia=c.get("frecuencia", "mensual"),
+            moneda=c.get("moneda", "DOP"),
+            categoria_id=c.get("categoria_id"),
+        )
+        created = create_suscripcion(user_jwt, user_id, data)
+        # Mark as auto_detectada
+        client = get_user_client(user_jwt)
+        try:
+            r = (
+                client.table("suscripciones")
+                .update({"auto_detectada": True})
+                .eq("id", created["id"])
+                .execute()
+            )
+            if r.data:
+                resultado.append(_enrich(r.data[0]))
+            else:
+                resultado.append(created)
+        except APIError:
+            resultado.append(created)
+    return resultado

--- a/backend/tests/test_fondo_emergencia.py
+++ b/backend/tests/test_fondo_emergencia.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_get_fondo_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/fondo-emergencia")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_fondo_requires_auth(client: AsyncClient) -> None:
+    response = await client.post("/api/v1/fondo-emergencia", json={"monto_actual": 5000})
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_depositar_requires_auth(client: AsyncClient) -> None:
+    response = await client.post("/api/v1/fondo-emergencia/depositar", json={"monto": 1000})
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_retirar_requires_auth(client: AsyncClient) -> None:
+    response = await client.post("/api/v1/fondo-emergencia/retirar", json={"monto": 500})
+    assert response.status_code == 403
+
+
+@patch("app.services.fondo_emergencia.get_user_client")
+def test_create_fondo_returns_enriched(mock_client: MagicMock) -> None:
+    from app.services.fondo_emergencia import create_fondo
+    from app.schemas.fondo_emergencia import FondoEmergenciaCreate
+
+    mock = MagicMock()
+    mock.table.return_value.insert.return_value.execute.return_value = MagicMock(
+        data=[{
+            "id": "fe-1", "user_id": "u-1", "monto_actual": "5000.00",
+            "meta_meses": 3, "notas": None, "created_at": "2026-01-01",
+        }]
+    )
+    mock.table.return_value.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    mock_client.return_value = mock
+
+    result = create_fondo("jwt", "u-1", FondoEmergenciaCreate(monto_actual=5000, meta_meses=3))
+    assert result["monto_actual"] == 5000.0
+    assert "meta_calculada" in result
+    assert "porcentaje" in result
+
+
+@patch("app.services.fondo_emergencia.get_user_client")
+def test_get_or_none_returns_none_when_empty(mock_client: MagicMock) -> None:
+    from app.services.fondo_emergencia import get_or_none
+
+    mock = MagicMock()
+    mock.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = MagicMock(data=None)
+    mock_client.return_value = mock
+
+    result = get_or_none("jwt", "u-1")
+    assert result is None
+
+
+@patch("app.services.fondo_emergencia.get_user_client")
+def test_porcentaje_caps_at_100(mock_client: MagicMock) -> None:
+    from app.services.fondo_emergencia import _enrich
+
+    mock = MagicMock()
+    # egresos = [] so meta_calculada = 0, porcentaje = 0
+    mock.table.return_value.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    mock_client.return_value = mock
+
+    row = {"id": "x", "user_id": "u", "monto_actual": "999999.00", "meta_meses": 3, "notas": None}
+    result = _enrich(row, mock, "u")
+    assert result["porcentaje"] == 0.0  # no egresos → meta=0 → porcentaje=0
+
+
+@patch("app.services.fondo_emergencia.get_user_client")
+def test_depositar_adds_monto(mock_client: MagicMock) -> None:
+    from app.services.fondo_emergencia import depositar
+
+    fondo_data = {
+        "id": "fe-1", "user_id": "u-1", "monto_actual": "1000.00",
+        "meta_meses": 3, "notas": None, "meta_calculada": None, "porcentaje": 0.0,
+    }
+
+    mock = MagicMock()
+    q = MagicMock()
+    q.execute.return_value = MagicMock(data=None)
+    q.eq.return_value = q
+    q.maybe_single.return_value = q
+    q.select.return_value = q
+    q.update.return_value = q
+    # First call: get_or_none → egresos for meta calc
+    mock.table.return_value = q
+
+    with patch("app.services.fondo_emergencia.get_or_none") as mock_get, \
+         patch("app.services.fondo_emergencia.update_fondo") as mock_update:
+        mock_get.return_value = {**fondo_data, "monto_actual": 1000.0}
+        mock_update.return_value = {**fondo_data, "monto_actual": 1500.0}
+        mock_client.return_value = mock
+
+        result = depositar("jwt", "u-1", 500.0)
+        assert result["monto_actual"] == 1500.0

--- a/backend/tests/test_impulso.py
+++ b/backend/tests/test_impulso.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_evaluar_impulsos_requires_auth(client: AsyncClient) -> None:
+    response = await client.post("/api/v1/egresos/evaluar-impulsos?mes=3&year=2026")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_resumen_impulso_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/egresos/resumen-impulso?mes=3&year=2026")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_clasificar_impulso_requires_auth(client: AsyncClient) -> None:
+    response = await client.patch(
+        "/api/v1/egresos/some-id/clasificar-impulso",
+        json={"es_impulso": True},
+    )
+    assert response.status_code == 403
+
+
+@patch("app.services.impulso.get_user_client")
+def test_evaluar_impulsos_no_egresos_returns_zero(mock_client: MagicMock) -> None:
+    from app.services.impulso import evaluar_impulsos
+
+    mock = MagicMock()
+    q = MagicMock()
+    q.execute.return_value = MagicMock(data=[])
+    q.eq.return_value = q
+    q.select.return_value = q
+    mock.table.return_value = q
+    mock_client.return_value = mock
+
+    result = evaluar_impulsos("jwt", "u-1", 3, 2026)
+    assert result["evaluados"] == 0
+    assert result["marcados_impulso"] == 0
+
+
+@patch("app.services.impulso.get_user_client")
+def test_resumen_impulso_empty(mock_client: MagicMock) -> None:
+    from app.services.impulso import get_resumen_impulso
+
+    mock = MagicMock()
+    q = MagicMock()
+    q.execute.return_value = MagicMock(data=[])
+    q.eq.return_value = q
+    q.select.return_value = q
+    mock.table.return_value = q
+    mock_client.return_value = mock
+
+    result = get_resumen_impulso("jwt", "u-1", 3, 2026)
+    assert result["cantidad_impulso"] == 0
+    assert result["total_impulso"] == 0.0
+    assert result["porcentaje_del_total"] == 0.0
+
+
+@patch("app.services.impulso.get_user_client")
+def test_resumen_impulso_calculates_correctly(mock_client: MagicMock) -> None:
+    from app.services.impulso import get_resumen_impulso
+
+    mock = MagicMock()
+    q = MagicMock()
+    q.execute.return_value = MagicMock(data=[
+        {"monto": "1000.00", "is_impulso": True},
+        {"monto": "500.00", "is_impulso": False},
+        {"monto": "250.00", "is_impulso": True},
+    ])
+    q.eq.return_value = q
+    q.select.return_value = q
+    mock.table.return_value = q
+    mock_client.return_value = mock
+
+    result = get_resumen_impulso("jwt", "u-1", 3, 2026)
+    assert result["cantidad_impulso"] == 2
+    assert result["total_impulso"] == 1250.0
+    assert round(result["porcentaje_del_total"], 1) == round(1250 / 1750 * 100, 1)
+
+
+@patch("app.services.impulso.get_user_client")
+def test_clasificar_impulso_not_found_raises_404(mock_client: MagicMock) -> None:
+    from fastapi import HTTPException
+    from app.services.impulso import clasificar_impulso
+
+    mock = MagicMock()
+    q = MagicMock()
+    q.execute.return_value = MagicMock(data=[])
+    q.eq.return_value = q
+    q.update.return_value = q
+    mock.table.return_value = q
+    mock_client.return_value = mock
+
+    with pytest.raises(HTTPException) as exc:
+        clasificar_impulso("jwt", "u-1", "bad-id", True)
+    assert exc.value.status_code == 404

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_get_profile_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/profiles/me")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_profile_requires_auth(client: AsyncClient) -> None:
+    response = await client.patch("/api/v1/profiles/me", json={"salario_mensual_neto": 50000})
+    assert response.status_code == 403
+
+
+@patch("app.services.profiles.get_user_client")
+def test_get_or_create_creates_when_missing(mock_client: MagicMock) -> None:
+    from app.services.profiles import get_or_create_profile
+
+    mock = MagicMock()
+    # First call returns None (no existing profile)
+    mock.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = MagicMock(data=None)
+    mock.table.return_value.insert.return_value.execute.return_value = MagicMock(
+        data=[{"user_id": "u-1", "salario_mensual_neto": None, "mostrar_horas_trabajo": False}]
+    )
+    mock_client.return_value = mock
+
+    result = get_or_create_profile("jwt", "u-1")
+    assert result["user_id"] == "u-1"
+    assert result["horas_por_peso"] is None
+
+
+@patch("app.services.profiles.get_user_client")
+def test_horas_por_peso_calculated(mock_client: MagicMock) -> None:
+    from app.services.profiles import get_or_create_profile
+
+    mock = MagicMock()
+    mock.table.return_value.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value = MagicMock(
+        data={"user_id": "u-1", "salario_mensual_neto": "16000.00", "mostrar_horas_trabajo": True}
+    )
+    mock_client.return_value = mock
+
+    result = get_or_create_profile("jwt", "u-1")
+    assert result["horas_por_peso"] is not None
+    # 160 / 16000 = 0.01 horas por peso
+    assert abs(result["horas_por_peso"] - 0.01) < 0.001
+
+
+@patch("app.services.profiles.get_user_client")
+def test_update_profile_sets_salario(mock_client: MagicMock) -> None:
+    from app.services.profiles import update_profile
+    from app.schemas.profile import ProfileUpdate
+
+    mock = MagicMock()
+    mock.table.return_value.upsert.return_value.execute.return_value = MagicMock(
+        data=[{"user_id": "u-1", "salario_mensual_neto": "50000.00", "mostrar_horas_trabajo": False}]
+    )
+    mock_client.return_value = mock
+
+    result = update_profile("jwt", "u-1", ProfileUpdate(salario_mensual_neto=50000))
+    assert result["salario_mensual_neto"] == 50000.0
+    assert result["horas_por_peso"] is not None

--- a/backend/tests/test_suscripciones.py
+++ b/backend/tests/test_suscripciones.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_list_suscripciones_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/suscripciones")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_suscripcion_requires_auth(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/v1/suscripciones",
+        json={"nombre": "Netflix", "monto": 500, "frecuencia": "mensual"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_resumen_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/suscripciones/resumen")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_detectar_requires_auth(client: AsyncClient) -> None:
+    response = await client.post("/api/v1/suscripciones/detectar")
+    assert response.status_code == 403
+
+
+@patch("app.services.suscripciones.get_user_client")
+def test_create_suscripcion_adds_monto_mensual(mock_client: MagicMock) -> None:
+    from app.services.suscripciones import create_suscripcion
+    from app.schemas.suscripcion import SuscripcionCreate
+
+    mock = MagicMock()
+    mock.table.return_value.insert.return_value.execute.return_value = MagicMock(
+        data=[{
+            "id": "s-1", "user_id": "u-1", "nombre": "Netflix",
+            "monto": "500.00", "frecuencia": "mensual", "moneda": "DOP",
+            "activa": True, "auto_detectada": False,
+            "fecha_proximo_cobro": None, "notas": None,
+        }]
+    )
+    mock_client.return_value = mock
+
+    result = create_suscripcion("jwt", "u-1", SuscripcionCreate(nombre="Netflix", monto=500, frecuencia="mensual"))
+    assert result["monto_mensual"] == 500.0
+
+
+@patch("app.services.suscripciones.get_user_client")
+def test_resumen_calculates_totals(mock_client: MagicMock) -> None:
+    from app.services.suscripciones import get_resumen
+
+    mock = MagicMock()
+    mock.table.return_value.select.return_value.eq.return_value.order.return_value.execute.return_value = MagicMock(
+        data=[
+            {"id": "s-1", "nombre": "Netflix", "monto": "500.00", "frecuencia": "mensual",
+             "moneda": "DOP", "activa": True, "auto_detectada": False, "fecha_proximo_cobro": None, "notas": None},
+            {"id": "s-2", "nombre": "Spotify", "monto": "1200.00", "frecuencia": "anual",
+             "moneda": "DOP", "activa": True, "auto_detectada": False, "fecha_proximo_cobro": None, "notas": None},
+        ]
+    )
+    mock_client.return_value = mock
+
+    result = get_resumen("jwt", "u-1")
+    assert result["cantidad_activas"] == 2
+    assert result["total_mensual"] > 0
+    assert result["total_anual"] == round(result["total_mensual"] * 12, 2)
+
+
+@patch("app.services.suscripciones.get_user_client")
+def test_delete_suscripcion_not_found_raises_404(mock_client: MagicMock) -> None:
+    from fastapi import HTTPException
+    from app.services.suscripciones import delete_suscripcion
+
+    mock = MagicMock()
+    q = MagicMock()
+    q.execute.return_value = MagicMock(data=[])
+    q.eq.return_value = q
+    q.delete.return_value = q
+    mock.table.return_value = q
+    mock_client.return_value = mock
+
+    with pytest.raises(HTTPException) as exc:
+        delete_suscripcion("jwt", "u-1", "bad-id")
+    assert exc.value.status_code == 404

--- a/supabase/migrations/20260316000001_fondo_emergencia.sql
+++ b/supabase/migrations/20260316000001_fondo_emergencia.sql
@@ -1,0 +1,33 @@
+CREATE TABLE fondo_emergencia (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+    monto_actual NUMERIC(12,2) NOT NULL DEFAULT 0,
+    meta_meses INT NOT NULL DEFAULT 3 CHECK (meta_meses IN (1, 3, 6)),
+    notas TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE fondo_emergencia ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own fondo_emergencia"
+    ON fondo_emergencia FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own fondo_emergencia"
+    ON fondo_emergencia FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own fondo_emergencia"
+    ON fondo_emergencia FOR UPDATE
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own fondo_emergencia"
+    ON fondo_emergencia FOR DELETE
+    USING (auth.uid() = user_id);
+
+CREATE TRIGGER update_fondo_emergencia_updated_at
+    BEFORE UPDATE ON fondo_emergencia
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX idx_fondo_emergencia_user_id ON fondo_emergencia(user_id);

--- a/supabase/migrations/20260316000002_impulso_egresos.sql
+++ b/supabase/migrations/20260316000002_impulso_egresos.sql
@@ -1,0 +1,4 @@
+ALTER TABLE egresos ADD COLUMN IF NOT EXISTS is_impulso BOOLEAN DEFAULT NULL;
+ALTER TABLE egresos ADD COLUMN IF NOT EXISTS impulso_clasificado BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_egresos_is_impulso ON egresos(user_id, is_impulso);

--- a/supabase/migrations/20260316000003_suscripciones.sql
+++ b/supabase/migrations/20260316000003_suscripciones.sql
@@ -1,0 +1,40 @@
+CREATE TABLE suscripciones (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    nombre TEXT NOT NULL,
+    monto NUMERIC(12,2) NOT NULL,
+    moneda TEXT NOT NULL DEFAULT 'DOP',
+    frecuencia TEXT NOT NULL CHECK (frecuencia IN ('mensual', 'anual', 'semanal', 'trimestral')),
+    categoria_id UUID REFERENCES categorias(id),
+    fecha_proximo_cobro DATE,
+    activa BOOLEAN NOT NULL DEFAULT true,
+    auto_detectada BOOLEAN NOT NULL DEFAULT false,
+    notas TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE suscripciones ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own suscripciones"
+    ON suscripciones FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own suscripciones"
+    ON suscripciones FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own suscripciones"
+    ON suscripciones FOR UPDATE
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own suscripciones"
+    ON suscripciones FOR DELETE
+    USING (auth.uid() = user_id);
+
+CREATE TRIGGER update_suscripciones_updated_at
+    BEFORE UPDATE ON suscripciones
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX idx_suscripciones_user_id ON suscripciones(user_id);
+CREATE INDEX idx_suscripciones_activa ON suscripciones(user_id, activa);

--- a/supabase/migrations/20260316000004_profiles.sql
+++ b/supabase/migrations/20260316000004_profiles.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS profiles (
+    user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    salario_mensual_neto NUMERIC(12,2) DEFAULT NULL,
+    mostrar_horas_trabajo BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own profile"
+    ON profiles FOR SELECT
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own profile"
+    ON profiles FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own profile"
+    ON profiles FOR UPDATE
+    USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own profile"
+    ON profiles FOR DELETE
+    USING (auth.uid() = user_id);
+
+CREATE TRIGGER update_profiles_updated_at
+    BEFORE UPDATE ON profiles
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Issues
Closes #87, #89, #91, #93

## Changes
- **Fondo de emergencia** (#87): tabla + CRUD + depósito/retiro + meta auto-calculada (avg egresos × meta_meses) + porcentaje
- **Detector impulso** (#89): campos is_impulso/impulso_clasificado en egresos + evaluación automática (2 criterios) + clasificación manual + resumen mensual
- **Suscripciones** (#91): tabla + CRUD + monto_mensual calculado por frecuencia + detección automática de patrones recurrentes + resumen KPIs
- **Profiles** (#93): tabla profiles + salario_mensual_neto + toggle mostrar_horas_trabajo + horas_por_peso calculado

## Migrations
- 20260316000001_fondo_emergencia.sql
- 20260316000002_impulso_egresos.sql
- 20260316000003_suscripciones.sql
- 20260316000004_profiles.sql