### PR TITLE
[Backend] Wave 8 Fase 3 — retos, educacion, comparativa deuda-ahorro

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -3,7 +3,10 @@ from fastapi import APIRouter
 from app.api.v1.routes.categorias import router as categorias_router
 from app.api.v1.routes.fondo_emergencia import router as fondo_emergencia_router
 from app.api.v1.routes.impulso import router as impulso_router
+from app.api.v1.routes.comparativa import router as comparativa_router
+from app.api.v1.routes.educacion import router as educacion_router
 from app.api.v1.routes.profiles import router as profiles_router
+from app.api.v1.routes.retos import router as retos_router
 from app.api.v1.routes.suscripciones import router as suscripciones_router
 from app.api.v1.routes.dashboard import router as dashboard_router
 from app.api.v1.routes.egresos import router as egresos_router
@@ -31,4 +34,7 @@ api_router.include_router(notificaciones_router)
 api_router.include_router(fondo_emergencia_router)
 api_router.include_router(impulso_router)
 api_router.include_router(suscripciones_router)
+api_router.include_router(retos_router)
+api_router.include_router(educacion_router)
+api_router.include_router(comparativa_router)
 api_router.include_router(profiles_router)

--- a/backend/app/api/v1/routes/comparativa.py
+++ b/backend/app/api/v1/routes/comparativa.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+
+from app.core.security import get_current_user, get_raw_token
+import app.services.comparativa as svc
+
+router = APIRouter(prefix="/dashboard", tags=["comparativa"])
+
+
+@router.get("/comparativa-deuda-ahorro")
+async def get_comparativa(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    return svc.get_comparativa(user_jwt=token, user_id=current_user["user_id"])

--- a/backend/app/api/v1/routes/educacion.py
+++ b/backend/app/api/v1/routes/educacion.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends
+
+from app.core.security import get_current_user, get_raw_token
+import app.services.educacion as svc
+
+router = APIRouter(prefix="/educacion", tags=["educacion"])
+
+
+@router.get("/lecciones")
+async def get_lecciones(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    return svc.get_lecciones(user_jwt=token, user_id=current_user["user_id"])
+
+
+@router.post("/lecciones/{leccion_id}/completar")
+async def completar(
+    leccion_id: str,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    return svc.marcar_completada(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        leccion_id=leccion_id,
+    )

--- a/backend/app/api/v1/routes/retos.py
+++ b/backend/app/api/v1/routes/retos.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, Depends
+
+from app.core.security import get_current_user, get_raw_token
+import app.services.retos as svc
+
+router = APIRouter(prefix="/retos", tags=["retos"])
+
+
+@router.get("/catalogo")
+async def get_catalogo(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    return svc.get_catalogo(user_jwt=token)
+
+
+@router.get("/mis-retos")
+async def get_mis_retos(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    return svc.get_mis_retos(user_jwt=token, user_id=current_user["user_id"])
+
+
+@router.post("/aceptar/{reto_id}", status_code=201)
+async def aceptar_reto(
+    reto_id: str,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    return svc.aceptar_reto(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        reto_id=reto_id,
+    )
+
+
+@router.post("/checkin/{user_reto_id}")
+async def checkin(
+    user_reto_id: str,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    return svc.checkin_reto(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        user_reto_id=user_reto_id,
+    )
+
+
+@router.patch("/abandonar/{user_reto_id}", status_code=204)
+async def abandonar(
+    user_reto_id: str,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+):
+    svc.abandonar_reto(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        user_reto_id=user_reto_id,
+    )

--- a/backend/app/schemas/comparativa.py
+++ b/backend/app/schemas/comparativa.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class ItemComparativa(BaseModel):
+    nombre: str
+    tipo: str  # "deuda" | "ahorro"
+    monto: float
+    tasa_anual: Optional[float] = None
+    costo_o_rendimiento_mensual: float
+
+
+class ComparativaResponse(BaseModel):
+    deudas: list[ItemComparativa]
+    ahorros: list[ItemComparativa]
+    total_costo_deuda: float
+    total_rendimiento_ahorro: float
+    diferencia: float  # positivo = deuda > ahorro -> conviene pagar deuda
+    recomendacion: str

--- a/backend/app/schemas/educacion.py
+++ b/backend/app/schemas/educacion.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from typing import Optional, Any
+
+
+class LeccionResponse(BaseModel):
+    id: str
+    titulo: str
+    descripcion_corta: str
+    contenido_json: dict[str, Any]
+    nivel: str
+    duracion_minutos: int
+    orden: int
+    completada: bool = False
+
+    model_config = {"from_attributes": True}
+
+
+class MarcarCompletadaResponse(BaseModel):
+    leccion_id: str
+    completada: bool

--- a/backend/app/schemas/reto.py
+++ b/backend/app/schemas/reto.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class RetoBase(BaseModel):
+    id: str
+    titulo: str
+    descripcion: str
+    tipo: str
+    ahorro_estimado: Optional[float] = None
+    icono: Optional[str] = None
+
+
+class UserRetoResponse(BaseModel):
+    id: str
+    reto_id: str
+    titulo: str
+    descripcion: str
+    tipo: str
+    ahorro_estimado: Optional[float] = None
+    icono: Optional[str] = None
+    estado: str
+    racha_dias: int
+    ultimo_checkin: Optional[str] = None
+    iniciado_en: str
+    puede_checkin_hoy: bool  # computed: ultimo_checkin != today
+
+    model_config = {"from_attributes": True}
+
+
+class CheckinResponse(BaseModel):
+    racha_dias: int
+    message: str

--- a/backend/app/services/comparativa.py
+++ b/backend/app/services/comparativa.py
@@ -1,0 +1,86 @@
+from app.core.supabase_client import get_user_client
+from app.services.base import _handle_api_error
+
+# Proxy rate used for savings accounts in RD (annual %)
+_TASA_AHORRO_PROXY = 4.0
+
+
+def get_comparativa(user_jwt: str, user_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        prestamos = (
+            client.table("prestamos")
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("estado", "activo")
+            .execute()
+        )
+        metas = (
+            client.table("metas_ahorro")
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("estado", "activa")
+            .execute()
+        )
+
+        deudas = []
+        total_costo = 0.0
+        for p in prestamos.data or []:
+            tasa = float(p.get("tasa_interes", 0) or 0)
+            pendiente = float(p.get("monto_pendiente", 0) or 0)
+            costo_mensual = pendiente * (tasa / 100 / 12)
+            deudas.append(
+                {
+                    "nombre": p.get("descripcion") or p.get("prestamista", "Prestamo"),
+                    "tipo": "deuda",
+                    "monto": pendiente,
+                    "tasa_anual": tasa,
+                    "costo_o_rendimiento_mensual": round(costo_mensual, 2),
+                }
+            )
+            total_costo += costo_mensual
+
+        ahorros = []
+        total_rendimiento = 0.0
+        for m in metas.data or []:
+            monto_actual = float(m.get("monto_actual", 0) or 0)
+            rendimiento_mensual = monto_actual * (_TASA_AHORRO_PROXY / 100 / 12)
+            ahorros.append(
+                {
+                    "nombre": m.get("nombre", "Meta de ahorro"),
+                    "tipo": "ahorro",
+                    "monto": monto_actual,
+                    "tasa_anual": _TASA_AHORRO_PROXY,
+                    "costo_o_rendimiento_mensual": round(rendimiento_mensual, 2),
+                }
+            )
+            total_rendimiento += rendimiento_mensual
+
+        diferencia = total_costo - total_rendimiento
+        if diferencia > 0:
+            recomendacion = (
+                f"Tus deudas te cuestan RD${total_costo:.0f}/mes en intereses vs "
+                f"RD${total_rendimiento:.0f}/mes que genera tu ahorro. "
+                "Conviene priorizar el pago de deudas."
+            )
+        elif diferencia < -50:
+            recomendacion = (
+                f"Tu ahorro genera RD${total_rendimiento:.0f}/mes, mas que el costo de "
+                f"tus deudas (RD${total_costo:.0f}/mes). Puedes continuar ahorrando."
+            )
+        else:
+            recomendacion = (
+                "El costo de tus deudas y el rendimiento de tu ahorro estan balanceados. "
+                "Mantén ambos."
+            )
+
+        return {
+            "deudas": deudas,
+            "ahorros": ahorros,
+            "total_costo_deuda": round(total_costo, 2),
+            "total_rendimiento_ahorro": round(total_rendimiento, 2),
+            "diferencia": round(diferencia, 2),
+            "recomendacion": recomendacion,
+        }
+    except Exception as e:
+        _handle_api_error(e)

--- a/backend/app/services/educacion.py
+++ b/backend/app/services/educacion.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+
+from app.core.supabase_client import get_user_client
+from app.services.base import _handle_api_error
+
+
+def get_lecciones(user_jwt: str, user_id: str) -> list[dict]:
+    client = get_user_client(user_jwt)
+    try:
+        lecciones = client.table("lecciones").select("*").order("nivel").order("orden").execute()
+        progreso = (
+            client.table("user_lecciones")
+            .select("leccion_id, completada")
+            .eq("user_id", user_id)
+            .execute()
+        )
+        completadas = {
+            p["leccion_id"] for p in (progreso.data or []) if p["completada"]
+        }
+        result = []
+        for leccion in lecciones.data or []:
+            result.append({**leccion, "completada": leccion["id"] in completadas})
+        return result
+    except Exception as e:
+        _handle_api_error(e)
+
+
+def marcar_completada(user_jwt: str, user_id: str, leccion_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        client.table("user_lecciones").upsert(
+            {
+                "user_id": user_id,
+                "leccion_id": leccion_id,
+                "completada": True,
+                "completada_en": datetime.now(timezone.utc).isoformat(),
+            },
+            on_conflict="user_id,leccion_id",
+        ).execute()
+        return {"leccion_id": leccion_id, "completada": True}
+    except Exception as e:
+        _handle_api_error(e)

--- a/backend/app/services/retos.py
+++ b/backend/app/services/retos.py
@@ -1,0 +1,95 @@
+from datetime import date
+
+from fastapi import HTTPException
+
+from app.core.supabase_client import get_user_client
+from app.services.base import _handle_api_error
+
+
+def get_catalogo(user_jwt: str) -> list[dict]:
+    client = get_user_client(user_jwt)
+    try:
+        r = client.table("retos").select("*").order("tipo").execute()
+        return r.data or []
+    except Exception as e:
+        _handle_api_error(e)
+
+
+def get_mis_retos(user_jwt: str, user_id: str) -> list[dict]:
+    client = get_user_client(user_jwt)
+    try:
+        r = (
+            client.table("user_retos")
+            .select("*, retos(titulo, descripcion, tipo, ahorro_estimado, icono)")
+            .eq("user_id", user_id)
+            .eq("estado", "activo")
+            .execute()
+        )
+        today = date.today().isoformat()
+        result = []
+        for ur in r.data or []:
+            reto = ur.get("retos") or {}
+            result.append(
+                {
+                    "id": ur["id"],
+                    "reto_id": ur["reto_id"],
+                    "titulo": reto.get("titulo", ""),
+                    "descripcion": reto.get("descripcion", ""),
+                    "tipo": reto.get("tipo", ""),
+                    "ahorro_estimado": float(reto.get("ahorro_estimado") or 0),
+                    "icono": reto.get("icono"),
+                    "estado": ur["estado"],
+                    "racha_dias": ur["racha_dias"],
+                    "ultimo_checkin": ur.get("ultimo_checkin"),
+                    "iniciado_en": ur["iniciado_en"],
+                    "puede_checkin_hoy": ur.get("ultimo_checkin") != today,
+                }
+            )
+        return result
+    except Exception as e:
+        _handle_api_error(e)
+
+
+def aceptar_reto(user_jwt: str, user_id: str, reto_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        r = client.table("user_retos").insert({"user_id": user_id, "reto_id": reto_id}).execute()
+        return r.data[0]
+    except Exception as e:
+        _handle_api_error(e)
+
+
+def checkin_reto(user_jwt: str, user_id: str, user_reto_id: str) -> dict:
+    client = get_user_client(user_jwt)
+    try:
+        today = date.today().isoformat()
+        existing = (
+            client.table("user_retos")
+            .select("*")
+            .eq("id", user_reto_id)
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        )
+        ur = existing.data
+        if ur.get("ultimo_checkin") == today:
+            raise HTTPException(status_code=400, detail="Ya hiciste check-in hoy")
+        new_racha = ur["racha_dias"] + 1
+        client.table("user_retos").update(
+            {"racha_dias": new_racha, "ultimo_checkin": today}
+        ).eq("id", user_reto_id).execute()
+        return {"racha_dias": new_racha, "message": f"Racha de {new_racha} dias!"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        _handle_api_error(e)
+
+
+def abandonar_reto(user_jwt: str, user_id: str, user_reto_id: str) -> None:
+    client = get_user_client(user_jwt)
+    try:
+        client.table("user_retos").update({"estado": "abandonado"}).eq(
+            "id", user_reto_id
+        ).eq("user_id", user_id).execute()
+    except Exception as e:
+        _handle_api_error(e)

--- a/backend/tests/test_comparativa.py
+++ b/backend/tests/test_comparativa.py
@@ -1,0 +1,117 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.comparativa import get_comparativa
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(prestamos_data: list, metas_data: list) -> MagicMock:
+    """Build a mock client returning different data per table."""
+    client = MagicMock()
+
+    def table_side_effect(name: str) -> MagicMock:
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+
+        if name == "prestamos":
+            mock_q.execute.return_value = MagicMock(data=prestamos_data)
+        elif name == "metas_ahorro":
+            mock_q.execute.return_value = MagicMock(data=metas_data)
+        else:
+            mock_q.execute.return_value = MagicMock(data=[])
+
+        mock_q.select.return_value = mock_q
+        mock_q.eq.return_value = mock_q
+        mock_table.select.return_value = mock_q
+        return mock_table
+
+    client.table.side_effect = table_side_effect
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetComparativa:
+    @patch("app.services.comparativa.get_user_client")
+    def test_response_structure(self, mock_gc: MagicMock) -> None:
+        mock_gc.return_value = _make_client([], [])
+        result = get_comparativa("token", "user-1")
+
+        assert "deudas" in result
+        assert "ahorros" in result
+        assert "total_costo_deuda" in result
+        assert "total_rendimiento_ahorro" in result
+        assert "diferencia" in result
+        assert "recomendacion" in result
+        assert isinstance(result["recomendacion"], str)
+
+    @patch("app.services.comparativa.get_user_client")
+    def test_no_debts_no_savings_zero_totals(self, mock_gc: MagicMock) -> None:
+        mock_gc.return_value = _make_client([], [])
+        result = get_comparativa("token", "user-1")
+
+        assert result["total_costo_deuda"] == 0.0
+        assert result["total_rendimiento_ahorro"] == 0.0
+        assert result["diferencia"] == 0.0
+        assert result["deudas"] == []
+        assert result["ahorros"] == []
+
+    @patch("app.services.comparativa.get_user_client")
+    def test_debt_cost_calculated_correctly(self, mock_gc: MagicMock) -> None:
+        # 12,000 at 12% annual = 1200/12 = 100/month
+        prestamo = {
+            "descripcion": "Prestamo auto",
+            "prestamista": "Banco",
+            "tasa_interes": "12.00",
+            "monto_pendiente": "12000.00",
+        }
+        mock_gc.return_value = _make_client([prestamo], [])
+        result = get_comparativa("token", "user-1")
+
+        assert len(result["deudas"]) == 1
+        assert result["deudas"][0]["costo_o_rendimiento_mensual"] == 120.0
+        assert result["total_costo_deuda"] == 120.0
+
+    @patch("app.services.comparativa.get_user_client")
+    def test_savings_rendimiento_calculated_correctly(self, mock_gc: MagicMock) -> None:
+        # 12,000 at 4% annual proxy = 480/12 = 40/month
+        meta = {"nombre": "Fondo emergencia", "monto_actual": "12000.00"}
+        mock_gc.return_value = _make_client([], [meta])
+        result = get_comparativa("token", "user-1")
+
+        assert len(result["ahorros"]) == 1
+        assert result["ahorros"][0]["costo_o_rendimiento_mensual"] == 40.0
+        assert result["total_rendimiento_ahorro"] == 40.0
+
+    @patch("app.services.comparativa.get_user_client")
+    def test_diferencia_positive_when_debt_exceeds_savings(self, mock_gc: MagicMock) -> None:
+        prestamo = {"descripcion": "Deuda", "tasa_interes": "24.00", "monto_pendiente": "10000.00"}
+        meta = {"nombre": "Meta", "monto_actual": "1000.00"}
+        mock_gc.return_value = _make_client([prestamo], [meta])
+        result = get_comparativa("token", "user-1")
+
+        assert result["diferencia"] > 0
+
+    @patch("app.services.comparativa.get_user_client")
+    def test_recomendacion_is_non_empty_string(self, mock_gc: MagicMock) -> None:
+        prestamo = {"descripcion": "Deuda", "tasa_interes": "18.00", "monto_pendiente": "5000.00"}
+        mock_gc.return_value = _make_client([prestamo], [])
+        result = get_comparativa("token", "user-1")
+
+        assert len(result["recomendacion"]) > 10
+
+    @patch("app.services.comparativa.get_user_client")
+    def test_item_tipo_fields_correct(self, mock_gc: MagicMock) -> None:
+        prestamo = {"descripcion": "P1", "tasa_interes": "10.00", "monto_pendiente": "1000.00"}
+        meta = {"nombre": "M1", "monto_actual": "2000.00"}
+        mock_gc.return_value = _make_client([prestamo], [meta])
+        result = get_comparativa("token", "user-1")
+
+        assert result["deudas"][0]["tipo"] == "deuda"
+        assert result["ahorros"][0]["tipo"] == "ahorro"

--- a/backend/tests/test_educacion.py
+++ b/backend/tests/test_educacion.py
@@ -1,0 +1,125 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.educacion import get_lecciones, marcar_completada
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client_dual(lecciones_data: list, progreso_data: list) -> MagicMock:
+    """Build a mock client that returns different data per table name."""
+    client = MagicMock()
+
+    def table_side_effect(name: str) -> MagicMock:
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+
+        if name == "lecciones":
+            mock_q.execute.return_value = MagicMock(data=lecciones_data)
+        elif name == "user_lecciones":
+            mock_q.execute.return_value = MagicMock(data=progreso_data)
+
+        mock_q.select.return_value = mock_q
+        mock_q.eq.return_value = mock_q
+        mock_q.order.return_value = mock_q
+        mock_q.upsert.return_value = mock_q
+        mock_table.select.return_value = mock_q
+        mock_table.upsert.return_value = mock_q
+        return mock_table
+
+    client.table.side_effect = table_side_effect
+    return client
+
+
+# ---------------------------------------------------------------------------
+# get_lecciones
+# ---------------------------------------------------------------------------
+
+class TestGetLecciones:
+    @patch("app.services.educacion.get_user_client")
+    def test_returns_lecciones_with_completada_false(self, mock_gc: MagicMock) -> None:
+        leccion = {
+            "id": "l1",
+            "titulo": "El presupuesto 50/30/20",
+            "descripcion_corta": "Aprende la regla",
+            "contenido_json": {"hook": "test"},
+            "nivel": "fundamentos",
+            "duracion_minutos": 3,
+            "orden": 1,
+        }
+        mock_gc.return_value = _make_client_dual([leccion], [])
+        result = get_lecciones("token", "user-1")
+        assert len(result) == 1
+        assert result[0]["completada"] is False
+
+    @patch("app.services.educacion.get_user_client")
+    def test_marks_completada_true_when_progreso_exists(self, mock_gc: MagicMock) -> None:
+        leccion = {
+            "id": "l1",
+            "titulo": "Fondo de emergencia",
+            "descripcion_corta": "3 meses",
+            "contenido_json": {"hook": "test"},
+            "nivel": "fundamentos",
+            "duracion_minutos": 3,
+            "orden": 2,
+        }
+        progreso = [{"leccion_id": "l1", "completada": True}]
+        mock_gc.return_value = _make_client_dual([leccion], progreso)
+        result = get_lecciones("token", "user-1")
+        assert result[0]["completada"] is True
+
+    @patch("app.services.educacion.get_user_client")
+    def test_incomplete_progress_not_counted(self, mock_gc: MagicMock) -> None:
+        leccion = {"id": "l1", "titulo": "x", "descripcion_corta": "y",
+                   "contenido_json": {}, "nivel": "control", "duracion_minutos": 3, "orden": 1}
+        progreso = [{"leccion_id": "l1", "completada": False}]
+        mock_gc.return_value = _make_client_dual([leccion], progreso)
+        result = get_lecciones("token", "user-1")
+        assert result[0]["completada"] is False
+
+    @patch("app.services.educacion.get_user_client")
+    def test_empty_lecciones_returns_empty_list(self, mock_gc: MagicMock) -> None:
+        mock_gc.return_value = _make_client_dual([], [])
+        result = get_lecciones("token", "user-1")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# marcar_completada
+# ---------------------------------------------------------------------------
+
+class TestMarcarCompletada:
+    @patch("app.services.educacion.get_user_client")
+    def test_returns_leccion_id_and_completada_true(self, mock_gc: MagicMock) -> None:
+        client = MagicMock()
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+        mock_q.execute.return_value = MagicMock(data=[])
+        mock_table.upsert.return_value = mock_q
+        client.table.return_value = mock_table
+        mock_gc.return_value = client
+
+        result = marcar_completada("token", "user-1", "l1")
+        assert result == {"leccion_id": "l1", "completada": True}
+
+    @patch("app.services.educacion.get_user_client")
+    def test_upsert_called_with_correct_fields(self, mock_gc: MagicMock) -> None:
+        client = MagicMock()
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+        mock_q.execute.return_value = MagicMock(data=[])
+        mock_table.upsert.return_value = mock_q
+        client.table.return_value = mock_table
+        mock_gc.return_value = client
+
+        marcar_completada("token", "user-1", "l1")
+        call_args = mock_table.upsert.call_args
+        payload = call_args[0][0]
+        assert payload["user_id"] == "user-1"
+        assert payload["leccion_id"] == "l1"
+        assert payload["completada"] is True
+        assert "completada_en" in payload

--- a/backend/tests/test_retos.py
+++ b/backend/tests/test_retos.py
@@ -1,0 +1,210 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.retos import (
+    abandonar_reto,
+    aceptar_reto,
+    checkin_reto,
+    get_catalogo,
+    get_mis_retos,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_simple_client(table_data: dict) -> MagicMock:
+    """Build a mock supabase client for simple select queries."""
+    client = MagicMock()
+
+    def table_side_effect(name: str) -> MagicMock:
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+        mock_q.execute.return_value = MagicMock(data=table_data.get(name, []))
+        mock_q.select.return_value = mock_q
+        mock_q.eq.return_value = mock_q
+        mock_q.order.return_value = mock_q
+        mock_q.insert.return_value = mock_q
+        mock_q.update.return_value = mock_q
+        mock_q.single.return_value = mock_q
+        mock_table.select.return_value = mock_q
+        mock_table.insert.return_value = mock_q
+        mock_table.update.return_value = mock_q
+        return mock_table
+
+    client.table.side_effect = table_side_effect
+    return client
+
+
+# ---------------------------------------------------------------------------
+# get_catalogo
+# ---------------------------------------------------------------------------
+
+class TestGetCatalogo:
+    @patch("app.services.retos.get_user_client")
+    def test_returns_retos_list(self, mock_gc: MagicMock) -> None:
+        reto = {"id": "r1", "titulo": "Sin cafe", "tipo": "semanal"}
+        mock_gc.return_value = _make_simple_client({"retos": [reto]})
+        result = get_catalogo("token")
+        assert result == [reto]
+
+    @patch("app.services.retos.get_user_client")
+    def test_empty_catalog_returns_empty_list(self, mock_gc: MagicMock) -> None:
+        mock_gc.return_value = _make_simple_client({"retos": []})
+        result = get_catalogo("token")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_mis_retos
+# ---------------------------------------------------------------------------
+
+class TestGetMisRetos:
+    @patch("app.services.retos.get_user_client")
+    def test_returns_active_retos_with_fields(self, mock_gc: MagicMock) -> None:
+        ur_row = {
+            "id": "ur1",
+            "reto_id": "r1",
+            "estado": "activo",
+            "racha_dias": 3,
+            "ultimo_checkin": "2026-03-15",
+            "iniciado_en": "2026-03-01T00:00:00Z",
+            "retos": {
+                "titulo": "Sin cafe",
+                "descripcion": "No compres cafe",
+                "tipo": "semanal",
+                "ahorro_estimado": 500,
+                "icono": "☕",
+            },
+        }
+        mock_gc.return_value = _make_simple_client({"user_retos": [ur_row]})
+        result = get_mis_retos("token", "user-1")
+        assert len(result) == 1
+        item = result[0]
+        assert item["id"] == "ur1"
+        assert item["titulo"] == "Sin cafe"
+        assert item["racha_dias"] == 3
+        assert "puede_checkin_hoy" in item
+
+    @patch("app.services.retos.get_user_client")
+    def test_no_active_retos_returns_empty(self, mock_gc: MagicMock) -> None:
+        mock_gc.return_value = _make_simple_client({"user_retos": []})
+        result = get_mis_retos("token", "user-1")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# aceptar_reto
+# ---------------------------------------------------------------------------
+
+class TestAceptarReto:
+    @patch("app.services.retos.get_user_client")
+    def test_inserts_and_returns_row(self, mock_gc: MagicMock) -> None:
+        row = {"id": "ur-new", "reto_id": "r1", "user_id": "user-1", "estado": "activo"}
+        client = MagicMock()
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+        mock_q.execute.return_value = MagicMock(data=[row])
+        mock_q.eq.return_value = mock_q
+        mock_table.insert.return_value = mock_q
+        client.table.return_value = mock_table
+        mock_gc.return_value = client
+        result = aceptar_reto("token", "user-1", "r1")
+        assert result["id"] == "ur-new"
+
+    @patch("app.services.retos.get_user_client")
+    def test_duplicate_reto_raises_409(self, mock_gc: MagicMock) -> None:
+        from postgrest import APIError
+        client = MagicMock()
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+        error = APIError({"code": "23505", "message": "unique_violation", "details": None, "hint": None})
+        mock_q.execute.side_effect = error
+        mock_table.insert.return_value = mock_q
+        client.table.return_value = mock_table
+        mock_gc.return_value = client
+        with pytest.raises(HTTPException) as exc_info:
+            aceptar_reto("token", "user-1", "r1")
+        assert exc_info.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# checkin_reto
+# ---------------------------------------------------------------------------
+
+class TestCheckinReto:
+    @patch("app.services.retos.get_user_client")
+    def test_checkin_increments_racha(self, mock_gc: MagicMock) -> None:
+        existing_row = {
+            "id": "ur1",
+            "user_id": "user-1",
+            "racha_dias": 2,
+            "ultimo_checkin": "2026-03-14",
+        }
+        client = MagicMock()
+        mock_table = MagicMock()
+        mock_select_q = MagicMock()
+        mock_select_q.execute.return_value = MagicMock(data=existing_row)
+        mock_select_q.eq.return_value = mock_select_q
+        mock_select_q.single.return_value = mock_select_q
+        mock_select_q.select.return_value = mock_select_q
+        mock_update_q = MagicMock()
+        mock_update_q.execute.return_value = MagicMock(data=[])
+        mock_update_q.eq.return_value = mock_update_q
+        mock_table.select.return_value = mock_select_q
+        mock_table.update.return_value = mock_update_q
+        client.table.return_value = mock_table
+        mock_gc.return_value = client
+
+        result = checkin_reto("token", "user-1", "ur1")
+        assert result["racha_dias"] == 3
+        assert "message" in result
+
+    @patch("app.services.retos.get_user_client")
+    def test_checkin_today_raises_400(self, mock_gc: MagicMock) -> None:
+        from datetime import date
+        today = date.today().isoformat()
+        existing_row = {
+            "id": "ur1",
+            "user_id": "user-1",
+            "racha_dias": 5,
+            "ultimo_checkin": today,
+        }
+        client = MagicMock()
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+        mock_q.execute.return_value = MagicMock(data=existing_row)
+        mock_q.eq.return_value = mock_q
+        mock_q.single.return_value = mock_q
+        mock_q.select.return_value = mock_q
+        mock_table.select.return_value = mock_q
+        client.table.return_value = mock_table
+        mock_gc.return_value = client
+
+        with pytest.raises(HTTPException) as exc_info:
+            checkin_reto("token", "user-1", "ur1")
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# abandonar_reto
+# ---------------------------------------------------------------------------
+
+class TestAbandonarReto:
+    @patch("app.services.retos.get_user_client")
+    def test_updates_estado_to_abandonado(self, mock_gc: MagicMock) -> None:
+        client = MagicMock()
+        mock_table = MagicMock()
+        mock_q = MagicMock()
+        mock_q.execute.return_value = MagicMock(data=[])
+        mock_q.eq.return_value = mock_q
+        mock_table.update.return_value = mock_q
+        client.table.return_value = mock_table
+        mock_gc.return_value = client
+
+        result = abandonar_reto("token", "user-1", "ur1")
+        assert result is None
+        mock_table.update.assert_called_once_with({"estado": "abandonado"})

--- a/supabase/migrations/20260316000005_retos.sql
+++ b/supabase/migrations/20260316000005_retos.sql
@@ -1,0 +1,32 @@
+CREATE TABLE retos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    titulo TEXT NOT NULL,
+    descripcion TEXT NOT NULL,
+    tipo TEXT NOT NULL CHECK (tipo IN ('semanal', 'mensual')),
+    ahorro_estimado NUMERIC(12,2),
+    icono TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE user_retos (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    reto_id UUID NOT NULL REFERENCES retos(id) ON DELETE CASCADE,
+    estado TEXT NOT NULL CHECK (estado IN ('activo', 'completado', 'abandonado')) DEFAULT 'activo',
+    racha_dias INT NOT NULL DEFAULT 0,
+    ultimo_checkin DATE,
+    iniciado_en TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completado_en TIMESTAMPTZ,
+    UNIQUE(user_id, reto_id)
+);
+ALTER TABLE user_retos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users manage own retos" ON user_retos FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE INDEX idx_user_retos_user_id ON user_retos(user_id);
+
+-- Seed de retos base
+INSERT INTO retos (titulo, descripcion, tipo, ahorro_estimado, icono) VALUES
+('Sin cafe fuera de casa', 'No compres cafe en establecimientos por 7 dias', 'semanal', 500, '☕'),
+('Semana sin delivery', 'Cocina en casa todos los dias esta semana', 'semanal', 1000, '🍳'),
+('Mes sin compras impulsivas', 'Evita compras no planificadas durante 30 dias', 'mensual', 3000, '🛍️'),
+('Ahorra el 10% extra', 'Deposita 10% adicional de tu ingreso al fondo de emergencia', 'mensual', 0, '💰'),
+('Revision diaria de gastos', 'Registra todos tus gastos durante 7 dias consecutivos', 'semanal', 0, '📊');

--- a/supabase/migrations/20260316000006_educacion.sql
+++ b/supabase/migrations/20260316000006_educacion.sql
@@ -1,0 +1,30 @@
+CREATE TABLE lecciones (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    titulo TEXT NOT NULL,
+    descripcion_corta TEXT NOT NULL,
+    contenido_json JSONB NOT NULL,
+    nivel TEXT NOT NULL CHECK (nivel IN ('fundamentos', 'control', 'crecimiento')),
+    duracion_minutos INT NOT NULL DEFAULT 3,
+    orden INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE user_lecciones (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    leccion_id UUID NOT NULL REFERENCES lecciones(id) ON DELETE CASCADE,
+    completada BOOLEAN NOT NULL DEFAULT false,
+    completada_en TIMESTAMPTZ,
+    UNIQUE(user_id, leccion_id)
+);
+ALTER TABLE user_lecciones ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users manage own progress" ON user_lecciones FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE INDEX idx_user_lecciones_user_id ON user_lecciones(user_id);
+
+-- Seed de lecciones
+INSERT INTO lecciones (titulo, descripcion_corta, contenido_json, nivel, duracion_minutos, orden) VALUES
+('El presupuesto 50/30/20', 'Aprende a distribuir tus ingresos con la regla mas popular', '{"hook":"La mayoria de las personas gasta sin plan","concept":"Divide tu ingreso: 50% necesidades, 30% deseos, 20% ahorro","action":"Revisa tus egresos del ultimo mes y clasificalos en estas 3 categorias","tip":"Finza ya calcula automaticamente tu balance — usalo como punto de partida"}', 'fundamentos', 3, 1),
+('Fondo de emergencia', 'Por que necesitas 3 meses de gastos guardados', '{"hook":"El 65% de las personas no podria cubrir un gasto inesperado de $5,000","concept":"Un fondo de emergencia evita que las crisis financieras se conviertan en deudas","action":"Calcula tus gastos mensuales promedio y define tu meta en Finza","tip":"Empieza con 1 mes de gastos y aumenta gradualmente"}', 'fundamentos', 3, 2),
+('Como salir de deudas', 'Metodo avalancha vs metodo bola de nieve', '{"hook":"Las deudas con alta tasa de interes pueden duplicarse en 5 anos","concept":"Avalancha: paga primero la deuda con mayor interes. Bola de nieve: paga primero la mas pequena","action":"Lista tus prestamos en Finza y calcula el costo mensual de intereses","tip":"Finza te muestra el costo real de tus deudas en la comparativa"}', 'control', 4, 3),
+('Invierte el 10%', 'El habito que mas impacto tiene en tu futuro financiero', '{"hook":"Invertir $1,000 mensuales durante 20 anos puede generar mas de $600,000","concept":"La inversion consistente supera a la inversion perfecta gracias al interes compuesto","action":"Configura una meta de ahorro en Finza y activa transferencia automatica","tip":"Empieza aunque sea con el 1% — el habito es mas importante que el monto"}', 'crecimiento', 4, 4),
+('Gastos hormiga', 'Los pequenos gastos que se comen tu ahorro', '{"hook":"Un cafe de $150 diario son $54,000 al ano","concept":"Los gastos pequenos y frecuentes son dificiles de notar pero acumulan una cifra enorme","action":"Activa el detector de impulso en Finza y revisa tus patrones del ultimo mes","tip":"No se trata de eliminar todos los placeres — sino de decidir conscientemente"}', 'control', 3, 5);


### PR DESCRIPTION
Closes #95, #97, #99

## Changes

### Issue #95 — Retos financieros
- `GET /retos/catalogo` — catalog of challenges (public to authenticated users)
- `GET /retos/mis-retos` — user's active challenges with streak and checkin status
- `POST /retos/aceptar/{reto_id}` — accept a challenge (201)
- `POST /retos/checkin/{user_reto_id}` — daily checkin, increments streak (400 if already done today)
- `PATCH /retos/abandonar/{user_reto_id}` — mark challenge as abandoned (204)
- Migration: `retos` + `user_retos` tables with RLS policy and seed data (5 challenges)

### Issue #97 — Educacion financiera
- `GET /educacion/lecciones` — lessons with per-user completion status merged
- `POST /educacion/lecciones/{leccion_id}/completar` — upsert progress record
- Migration: `lecciones` + `user_lecciones` tables with RLS policy and seed data (5 lessons)

### Issue #99 — Comparativa deuda vs ahorro
- `GET /dashboard/comparativa-deuda-ahorro` — monthly interest cost per active loan vs
  proxy yield (4% annual) per active savings goal, with auto-generated recommendation

## Tests
- 22 new unit tests (9 retos + 7 educacion + 6 comparativa)
- 254 total passing (0 failures), full regression green

## Files
- `backend/app/services/retos.py`
- `backend/app/services/educacion.py`
- `backend/app/services/comparativa.py`
- `backend/app/api/v1/routes/retos.py`
- `backend/app/api/v1/routes/educacion.py`
- `backend/app/api/v1/routes/comparativa.py`
- `backend/app/schemas/reto.py`
- `backend/app/schemas/educacion.py`
- `backend/app/schemas/comparativa.py`
- `backend/app/api/v1/router.py` (3 routers registered)
- `supabase/migrations/20260316000005_retos.sql`
- `supabase/migrations/20260316000006_educacion.sql`
- `backend/tests/test_retos.py`
- `backend/tests/test_educacion.py`
- `backend/tests/test_comparativa.py`