### PR TITLE
[Frontend] Prestamos: intereses, cuotas y alertas de pago proximo

### DIFF
--- a/frontend/src/features/prestamos/__tests__/PrestamosPage.test.tsx
+++ b/frontend/src/features/prestamos/__tests__/PrestamosPage.test.tsx
@@ -181,8 +181,13 @@ describe('PrestamosPage', () => {
   })
 
   it('renders pago hoy badge when proximo_pago is today', () => {
-    const today = new Date()
-    const todayStr = today.toISOString().split('T')[0]
+    // Build local date string to avoid UTC offset issues
+    const hoy = new Date()
+    hoy.setHours(0, 0, 0, 0)
+    const year = hoy.getFullYear()
+    const month = String(hoy.getMonth() + 1).padStart(2, '0')
+    const day = String(hoy.getDate()).padStart(2, '0')
+    const todayStr = `${year}-${month}-${day}`
     const prestamoHoy: Prestamo = {
       id: 'pre-hoy',
       tipo: 'me_deben',
@@ -196,14 +201,22 @@ describe('PrestamosPage', () => {
       proximo_pago: todayStr,
     }
     setupMocks({ prestamosData: [prestamoHoy] })
-    render(<PrestamosPage />)
-    expect(screen.getByRole('status', { name: /pago hoy/i })).toBeInTheDocument()
+    const { container } = render(<PrestamosPage />)
+    // The span badge has aria-label "Pago hoy"
+    const badge = container.querySelector('[aria-label="Pago hoy"]')
+    expect(badge).toBeInTheDocument()
   })
 
   it('renders "Pago en X dias" badge when proximo_pago is within 3 days', () => {
-    const futureDate = new Date()
+    // Build local date string +3 days from today to avoid UTC offset issues
+    const hoy = new Date()
+    hoy.setHours(0, 0, 0, 0)
+    const futureDate = new Date(hoy)
     futureDate.setDate(futureDate.getDate() + 3)
-    const futureDateStr = futureDate.toISOString().split('T')[0]
+    const year = futureDate.getFullYear()
+    const month = String(futureDate.getMonth() + 1).padStart(2, '0')
+    const day = String(futureDate.getDate()).padStart(2, '0')
+    const futureDateStr = `${year}-${month}-${day}`
     const prestamoCercano: Prestamo = {
       id: 'pre-3d',
       tipo: 'me_deben',
@@ -217,8 +230,9 @@ describe('PrestamosPage', () => {
       proximo_pago: futureDateStr,
     }
     setupMocks({ prestamosData: [prestamoCercano] })
-    render(<PrestamosPage />)
-    // Badge shows "Pago en 3 dias" — text may be split across icon + text nodes
-    expect(screen.getByRole('status', { name: /pago en 3 dias/i })).toBeInTheDocument()
+    const { container } = render(<PrestamosPage />)
+    // The span badge has aria-label "Pago en 3 dias"
+    const badge = container.querySelector('[aria-label="Pago en 3 dias"]')
+    expect(badge).toBeInTheDocument()
   })
 })

--- a/frontend/src/features/prestamos/components/PrestamoRow.tsx
+++ b/frontend/src/features/prestamos/components/PrestamoRow.tsx
@@ -5,8 +5,9 @@ import type { Prestamo, EstadoPrestamo } from '@/types/prestamo'
 function calcularDiasHastaProximoPago(proximoPago: string): number {
   const hoy = new Date()
   hoy.setHours(0, 0, 0, 0)
-  const fechaPago = new Date(proximoPago)
-  fechaPago.setHours(0, 0, 0, 0)
+  // Parse date parts directly to avoid UTC offset issues with ISO date strings
+  const [year, month, day] = proximoPago.split('-').map(Number)
+  const fechaPago = new Date(year, month - 1, day, 0, 0, 0, 0)
   return Math.round((fechaPago.getTime() - hoy.getTime()) / (1000 * 60 * 60 * 24))
 }
 


### PR DESCRIPTION
## Summary
- Agrega campos `tasa_interes` y `plazo_meses` al formulario de crear/editar prestamos
- Muestra badge `Cuota: $X/mes` en cada prestamo activo con cuota calculada
- Muestra alertas de pago proximo en PrestamoRow: rojo (hoy), amarillo (1-3 dias), naranja (4-7 dias), gris (>7 dias)
- Agrega soporte al tipo `advertencia` en NotificacionesPage con icono Bell y color naranja
- Actualiza i18n es/en con claves nuevas para formulario, cuota, intereses y alertas
- Corrige parsing de fechas UTC en calculo de dias hasta proximo pago

## Changes
- `types/prestamo.ts`: nuevos campos en `Prestamo`, `PrestamoCreate`, `PrestamoUpdate`
- `PrestamoForm.tsx`: schema Zod con `tasa_interes` y `plazo_meses`, inputs opcionales en el form
- `PrestamoRow.tsx`: componente `ProximoPagoBadge`, badges de cuota e intereses totales
- `PrestamosPage.tsx`: propaga `tasa_interes` y `plazo_meses` en create/update
- `NotificacionesPage.tsx`: tipo `advertencia` con Bell icon, seccion separada
- `i18n/locales/es.ts` + `en.ts`: claves nuevas en `prestamos` y `notificaciones`

## Tests
- 32 tests passing (13 PrestamosPage + 9 PrestamoRow + 10 NotificacionesPage)
- Nuevos: cuota_mensual badge, pago hoy badge, pago en X dias badge, advertencia notification
- Fix de flakiness por UTC offset en comparacion de fechas locales

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>