### PR TITLE
feat(backend): tarjetas CRUD — credit/debit card management

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -19,6 +19,7 @@ from app.api.v1.routes.prediccion import router as prediccion_router
 from app.api.v1.routes.prestamos import router as prestamos_router
 from app.api.v1.routes.presupuestos import router as presupuestos_router
 from app.api.v1.routes.score import router as score_router
+from app.api.v1.routes.tarjetas import router as tarjetas_router
 
 api_router = APIRouter()
 api_router.include_router(health_router, tags=["health"])
@@ -29,6 +30,7 @@ api_router.include_router(dashboard_router)
 api_router.include_router(prestamos_router)
 api_router.include_router(metas_router)
 api_router.include_router(presupuestos_router)
+api_router.include_router(tarjetas_router)
 api_router.include_router(recurrentes_router)
 api_router.include_router(score_router)
 api_router.include_router(prediccion_router)

--- a/backend/app/api/v1/routes/tarjetas.py
+++ b/backend/app/api/v1/routes/tarjetas.py
@@ -1,0 +1,80 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.core.security import get_current_user, get_raw_token
+from app.schemas.tarjeta import TarjetaCreate, TarjetaResponse, TarjetaUpdate
+from app.services import tarjetas as svc
+
+router = APIRouter(prefix="/tarjetas", tags=["tarjetas"])
+
+
+@router.get("", response_model=list[TarjetaResponse])
+async def list_tarjetas(
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> list[dict]:
+    return svc.get_tarjetas(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+    )
+
+
+@router.get("/{tarjeta_id}", response_model=TarjetaResponse)
+async def get_tarjeta(
+    tarjeta_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    result = svc.get_tarjeta(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        tarjeta_id=str(tarjeta_id),
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Tarjeta no encontrada.")
+    return result
+
+
+@router.post("", response_model=TarjetaResponse, status_code=201)
+async def create_tarjeta(
+    data: TarjetaCreate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    return svc.create_tarjeta(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        data=data,
+    )
+
+
+@router.put("/{tarjeta_id}", response_model=TarjetaResponse)
+async def update_tarjeta(
+    tarjeta_id: UUID,
+    data: TarjetaUpdate,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    result = svc.update_tarjeta(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        tarjeta_id=str(tarjeta_id),
+        data=data,
+    )
+    if not result:
+        raise HTTPException(status_code=404, detail="Tarjeta no encontrada.")
+    return result
+
+
+@router.delete("/{tarjeta_id}", status_code=204)
+async def delete_tarjeta(
+    tarjeta_id: UUID,
+    token: str = Depends(get_raw_token),
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    svc.delete_tarjeta(
+        user_jwt=token,
+        user_id=current_user["user_id"],
+        tarjeta_id=str(tarjeta_id),
+    )

--- a/backend/app/schemas/tarjeta.py
+++ b/backend/app/schemas/tarjeta.py
@@ -1,0 +1,116 @@
+import uuid
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+TipoTarjeta = Literal["credito", "debito"]
+RedTarjeta = Literal["visa", "mastercard", "amex", "otra"]
+ColorTarjeta = Literal["azul", "morado", "verde", "naranja"]
+
+
+class TarjetaCreate(BaseModel):
+    banco: str
+    titular: str
+    ultimos_digitos: str = Field(min_length=4, max_length=4)
+    tipo: TipoTarjeta
+    red: RedTarjeta
+    limite_credito: Optional[float] = None
+    saldo_actual: float = 0.0
+    fecha_corte: Optional[int] = Field(default=None, ge=1, le=31)
+    fecha_pago: Optional[int] = Field(default=None, ge=1, le=31)
+    color: ColorTarjeta = "azul"
+
+    @field_validator("banco")
+    @classmethod
+    def banco_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("El banco no puede estar vacio.")
+        return v.strip()
+
+    @field_validator("titular")
+    @classmethod
+    def titular_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("El titular no puede estar vacio.")
+        return v.strip()
+
+    @field_validator("ultimos_digitos")
+    @classmethod
+    def digitos_only_numeric(cls, v: str) -> str:
+        if not v.isdigit():
+            raise ValueError("ultimos_digitos debe contener solo numeros.")
+        return v
+
+    @field_validator("saldo_actual")
+    @classmethod
+    def saldo_not_negative(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("El saldo actual no puede ser negativo.")
+        return v
+
+    @field_validator("limite_credito")
+    @classmethod
+    def limite_positive(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v <= 0:
+            raise ValueError("El limite de credito debe ser mayor a 0.")
+        return v
+
+
+class TarjetaUpdate(BaseModel):
+    banco: Optional[str] = None
+    titular: Optional[str] = None
+    tipo: Optional[TipoTarjeta] = None
+    red: Optional[RedTarjeta] = None
+    limite_credito: Optional[float] = None
+    saldo_actual: Optional[float] = None
+    fecha_corte: Optional[int] = Field(default=None, ge=1, le=31)
+    fecha_pago: Optional[int] = Field(default=None, ge=1, le=31)
+    color: Optional[ColorTarjeta] = None
+    activa: Optional[bool] = None
+
+    @field_validator("banco")
+    @classmethod
+    def banco_not_empty(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            raise ValueError("El banco no puede estar vacio.")
+        return v.strip() if v else v
+
+    @field_validator("titular")
+    @classmethod
+    def titular_not_empty(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            raise ValueError("El titular no puede estar vacio.")
+        return v.strip() if v else v
+
+    @field_validator("saldo_actual")
+    @classmethod
+    def saldo_not_negative(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v < 0:
+            raise ValueError("El saldo actual no puede ser negativo.")
+        return v
+
+    @field_validator("limite_credito")
+    @classmethod
+    def limite_positive(cls, v: Optional[float]) -> Optional[float]:
+        if v is not None and v <= 0:
+            raise ValueError("El limite de credito debe ser mayor a 0.")
+        return v
+
+
+class TarjetaResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    banco: str
+    titular: str
+    ultimos_digitos: str
+    tipo: str
+    red: str
+    limite_credito: Optional[float] = None
+    saldo_actual: float
+    fecha_corte: Optional[int] = None
+    fecha_pago: Optional[int] = None
+    color: str
+    activa: bool
+    disponible: Optional[float] = None  # computed: limite_credito - saldo_actual
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/tarjetas.py
+++ b/backend/app/services/tarjetas.py
@@ -1,0 +1,131 @@
+from fastapi import HTTPException
+from postgrest import APIError
+
+from app.core.supabase_client import get_user_client
+from app.schemas.tarjeta import TarjetaCreate, TarjetaUpdate
+from app.services.base import _handle_api_error
+
+
+def _enrich_tarjeta(row: dict) -> dict:
+    """Add computed field 'disponible' for credit cards."""
+    if row.get("tipo") == "credito" and row.get("limite_credito") is not None:
+        limite = float(row["limite_credito"])
+        saldo = float(row.get("saldo_actual") or 0)
+        row["disponible"] = round(limite - saldo, 2)
+    else:
+        row["disponible"] = None
+    return row
+
+
+def get_tarjetas(user_jwt: str, user_id: str) -> list[dict]:
+    """Return all active tarjetas for the authenticated user."""
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("tarjetas")
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("activa", True)
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return [_enrich_tarjeta(row) for row in (response.data or [])]
+    except APIError as e:
+        _handle_api_error(e)
+    return []
+
+
+def get_tarjeta(user_jwt: str, user_id: str, tarjeta_id: str) -> dict | None:
+    """Return a single tarjeta by ID, scoped to the authenticated user."""
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("tarjetas")
+            .select("*")
+            .eq("id", tarjeta_id)
+            .eq("user_id", user_id)
+            .maybe_single()
+            .execute()
+        )
+        if not response.data:
+            return None
+        return _enrich_tarjeta(response.data)
+    except APIError as e:
+        _handle_api_error(e)
+    return None
+
+
+def create_tarjeta(user_jwt: str, user_id: str, data: TarjetaCreate) -> dict:
+    """Insert a new tarjeta and return the created record."""
+    client = get_user_client(user_jwt)
+    payload = data.model_dump(exclude_none=True)
+    payload["user_id"] = user_id
+
+    # Serialize numeric fields as strings for PostgREST
+    if "saldo_actual" in payload:
+        payload["saldo_actual"] = str(payload["saldo_actual"])
+    if "limite_credito" in payload and payload["limite_credito"] is not None:
+        payload["limite_credito"] = str(payload["limite_credito"])
+
+    try:
+        response = client.table("tarjetas").insert(payload).execute()
+        return _enrich_tarjeta(response.data[0])
+    except IndexError:
+        raise HTTPException(
+            status_code=500, detail="Tarjeta no encontrada tras insercion."
+        )
+    except APIError as e:
+        _handle_api_error(e)
+    return {}
+
+
+def update_tarjeta(
+    user_jwt: str, user_id: str, tarjeta_id: str, data: TarjetaUpdate
+) -> dict | None:
+    """Update an existing tarjeta and return the updated record."""
+    client = get_user_client(user_jwt)
+    payload = data.model_dump(exclude_unset=True)
+
+    if not payload:
+        raise HTTPException(status_code=422, detail="No hay campos para actualizar.")
+
+    if "saldo_actual" in payload and payload["saldo_actual"] is not None:
+        payload["saldo_actual"] = str(payload["saldo_actual"])
+    if "limite_credito" in payload and payload["limite_credito"] is not None:
+        payload["limite_credito"] = str(payload["limite_credito"])
+
+    try:
+        response = (
+            client.table("tarjetas")
+            .update(payload)
+            .eq("id", tarjeta_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+        if not response.data:
+            return None
+        return _enrich_tarjeta(response.data[0])
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Tarjeta no encontrada.")
+    except APIError as e:
+        _handle_api_error(e)
+    return None
+
+
+def delete_tarjeta(user_jwt: str, user_id: str, tarjeta_id: str) -> None:
+    """Hard-delete a tarjeta, scoped to the authenticated user."""
+    client = get_user_client(user_jwt)
+    try:
+        response = (
+            client.table("tarjetas")
+            .delete()
+            .eq("id", tarjeta_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Tarjeta no encontrada.")
+    except HTTPException:
+        raise
+    except APIError as e:
+        _handle_api_error(e)

--- a/backend/tests/test_tarjetas.py
+++ b/backend/tests/test_tarjetas.py
@@ -1,0 +1,478 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from postgrest import APIError
+
+
+# ---------------------------------------------------------------------------
+# Auth guard tests — no token -> 403
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_tarjetas_requires_auth(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/tarjetas")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_tarjeta_requires_auth(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/v1/tarjetas",
+        json={
+            "banco": "Banco Popular",
+            "titular": "Juan Perez",
+            "ultimos_digitos": "1234",
+            "tipo": "credito",
+            "red": "visa",
+        },
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_tarjeta_by_id_requires_auth(client: AsyncClient) -> None:
+    response = await client.get(
+        "/api/v1/tarjetas/00000000-0000-0000-0000-000000000001"
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_tarjeta_requires_auth(client: AsyncClient) -> None:
+    response = await client.put(
+        "/api/v1/tarjetas/00000000-0000-0000-0000-000000000001",
+        json={"saldo_actual": 500.0},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_tarjeta_requires_auth(client: AsyncClient) -> None:
+    response = await client.delete(
+        "/api/v1/tarjetas/00000000-0000-0000-0000-000000000001"
+    )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_tarjeta_create_invalid_digitos_length():
+    """ultimos_digitos must be exactly 4 characters."""
+    from pydantic import ValidationError
+
+    from app.schemas.tarjeta import TarjetaCreate
+
+    with pytest.raises(ValidationError):
+        TarjetaCreate(
+            banco="BPD",
+            titular="Test",
+            ultimos_digitos="123",  # only 3 chars
+            tipo="credito",
+            red="visa",
+        )
+
+
+def test_tarjeta_create_non_numeric_digitos():
+    """ultimos_digitos must contain only digits."""
+    from pydantic import ValidationError
+
+    from app.schemas.tarjeta import TarjetaCreate
+
+    with pytest.raises(ValidationError):
+        TarjetaCreate(
+            banco="BPD",
+            titular="Test",
+            ultimos_digitos="12ab",
+            tipo="credito",
+            red="visa",
+        )
+
+
+def test_tarjeta_create_invalid_tipo():
+    """tipo must be 'credito' or 'debito'."""
+    from pydantic import ValidationError
+
+    from app.schemas.tarjeta import TarjetaCreate
+
+    with pytest.raises(ValidationError):
+        TarjetaCreate(
+            banco="BPD",
+            titular="Test",
+            ultimos_digitos="1234",
+            tipo="prepagada",  # invalid
+            red="visa",
+        )
+
+
+def test_tarjeta_create_invalid_red():
+    """red must be one of visa, mastercard, amex, otra."""
+    from pydantic import ValidationError
+
+    from app.schemas.tarjeta import TarjetaCreate
+
+    with pytest.raises(ValidationError):
+        TarjetaCreate(
+            banco="BPD",
+            titular="Test",
+            ultimos_digitos="1234",
+            tipo="debito",
+            red="discover",  # invalid
+        )
+
+
+def test_tarjeta_create_negative_saldo_raises():
+    """saldo_actual cannot be negative."""
+    from pydantic import ValidationError
+
+    from app.schemas.tarjeta import TarjetaCreate
+
+    with pytest.raises(ValidationError):
+        TarjetaCreate(
+            banco="BPD",
+            titular="Test",
+            ultimos_digitos="1234",
+            tipo="credito",
+            red="visa",
+            saldo_actual=-100.0,
+        )
+
+
+def test_tarjeta_create_zero_limite_raises():
+    """limite_credito must be greater than 0 if provided."""
+    from pydantic import ValidationError
+
+    from app.schemas.tarjeta import TarjetaCreate
+
+    with pytest.raises(ValidationError):
+        TarjetaCreate(
+            banco="BPD",
+            titular="Test",
+            ultimos_digitos="1234",
+            tipo="credito",
+            red="visa",
+            limite_credito=0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service unit tests — mock supabase client
+# ---------------------------------------------------------------------------
+
+
+def test_create_tarjeta_credito():
+    """create_tarjeta inserts a credit card and sets user_id."""
+    from app.schemas.tarjeta import TarjetaCreate
+    from app.services.tarjetas import create_tarjeta
+
+    inserted_row = {
+        "id": "aaaa-1111",
+        "user_id": "u1",
+        "banco": "Banco Popular",
+        "titular": "Juan Perez",
+        "ultimos_digitos": "1234",
+        "tipo": "credito",
+        "red": "visa",
+        "limite_credito": "50000.00",
+        "saldo_actual": "5000.00",
+        "fecha_corte": 15,
+        "fecha_pago": 20,
+        "color": "azul",
+        "activa": True,
+        "created_at": "2026-03-17T00:00:00+00:00",
+        "updated_at": "2026-03-17T00:00:00+00:00",
+    }
+    mock_response = MagicMock()
+    mock_response.data = [inserted_row]
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.return_value = (
+        mock_response
+    )
+
+    data = TarjetaCreate(
+        banco="Banco Popular",
+        titular="Juan Perez",
+        ultimos_digitos="1234",
+        tipo="credito",
+        red="visa",
+        limite_credito=50000.0,
+        saldo_actual=5000.0,
+        fecha_corte=15,
+        fecha_pago=20,
+    )
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        result = create_tarjeta("fake-jwt", "u1", data)
+
+    insert_payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert insert_payload["user_id"] == "u1"
+    assert insert_payload["tipo"] == "credito"
+    assert insert_payload["banco"] == "Banco Popular"
+    # Computed field disponible = 50000 - 5000 = 45000
+    assert result["disponible"] == 45000.0
+
+
+def test_create_tarjeta_debito():
+    """create_tarjeta for debito card sets disponible=None."""
+    from app.schemas.tarjeta import TarjetaCreate
+    from app.services.tarjetas import create_tarjeta
+
+    inserted_row = {
+        "id": "bbbb-2222",
+        "user_id": "u1",
+        "banco": "BHD Leon",
+        "titular": "Maria Lopez",
+        "ultimos_digitos": "5678",
+        "tipo": "debito",
+        "red": "mastercard",
+        "limite_credito": None,
+        "saldo_actual": "10000.00",
+        "fecha_corte": None,
+        "fecha_pago": None,
+        "color": "verde",
+        "activa": True,
+        "created_at": "2026-03-17T00:00:00+00:00",
+        "updated_at": "2026-03-17T00:00:00+00:00",
+    }
+    mock_response = MagicMock()
+    mock_response.data = [inserted_row]
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.return_value = (
+        mock_response
+    )
+
+    data = TarjetaCreate(
+        banco="BHD Leon",
+        titular="Maria Lopez",
+        ultimos_digitos="5678",
+        tipo="debito",
+        red="mastercard",
+        saldo_actual=10000.0,
+        color="verde",
+    )
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        result = create_tarjeta("fake-jwt", "u1", data)
+
+    assert result["tipo"] == "debito"
+    assert result["disponible"] is None
+
+
+def test_get_tarjetas():
+    """get_tarjetas returns enriched list scoped to user."""
+    from app.services.tarjetas import get_tarjetas
+
+    rows = [
+        {
+            "id": "cccc-3333",
+            "user_id": "u1",
+            "banco": "Scotiabank",
+            "tipo": "credito",
+            "red": "visa",
+            "limite_credito": "100000.00",
+            "saldo_actual": "20000.00",
+            "activa": True,
+        }
+    ]
+    mock_response = MagicMock()
+    mock_response.data = rows
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        result = get_tarjetas("fake-jwt", "u1")
+
+    assert len(result) == 1
+    assert result[0]["id"] == "cccc-3333"
+    # disponible = 100000 - 20000
+    assert result[0]["disponible"] == 80000.0
+
+
+def test_get_tarjeta_not_found_returns_none():
+    """get_tarjeta returns None when the record does not exist."""
+    from app.services.tarjetas import get_tarjeta
+
+    mock_response = MagicMock()
+    mock_response.data = None
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.maybe_single.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        result = get_tarjeta("fake-jwt", "u1", "nonexistent-id")
+
+    assert result is None
+
+
+def test_update_saldo_actual():
+    """update_tarjeta with saldo_actual updates the record and recalculates disponible."""
+    from app.schemas.tarjeta import TarjetaUpdate
+    from app.services.tarjetas import update_tarjeta
+
+    updated_row = {
+        "id": "dddd-4444",
+        "user_id": "u1",
+        "banco": "BPD",
+        "tipo": "credito",
+        "red": "visa",
+        "limite_credito": "30000.00",
+        "saldo_actual": "8000.00",
+        "activa": True,
+    }
+    mock_response = MagicMock()
+    mock_response.data = [updated_row]
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    data = TarjetaUpdate(saldo_actual=8000.0)
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        result = update_tarjeta("fake-jwt", "u1", "dddd-4444", data)
+
+    update_payload = mock_client.table.return_value.update.call_args[0][0]
+    assert update_payload["saldo_actual"] == "8000.0"
+    assert result is not None
+    # disponible = 30000 - 8000 = 22000
+    assert result["disponible"] == 22000.0
+
+
+def test_update_tarjeta_no_fields_raises_422():
+    """update_tarjeta raises 422 when no fields are provided."""
+    from app.schemas.tarjeta import TarjetaUpdate
+    from app.services.tarjetas import update_tarjeta
+
+    mock_client = MagicMock()
+
+    data = TarjetaUpdate()  # no fields set
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            update_tarjeta("fake-jwt", "u1", "some-id", data)
+
+    assert exc_info.value.status_code == 422
+
+
+def test_delete_tarjeta():
+    """delete_tarjeta executes hard delete and does not raise when record exists."""
+    from app.services.tarjetas import delete_tarjeta
+
+    mock_response = MagicMock()
+    mock_response.data = [{"id": "eeee-5555"}]
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.delete.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        delete_tarjeta("fake-jwt", "u1", "eeee-5555")  # should not raise
+
+
+def test_delete_tarjeta_not_found_raises_404():
+    """delete_tarjeta raises 404 when no rows are deleted."""
+    from app.services.tarjetas import delete_tarjeta
+
+    mock_response = MagicMock()
+    mock_response.data = []  # empty = not found
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.delete.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = mock_response
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            delete_tarjeta("fake-jwt", "u1", "nonexistent-id")
+
+    assert exc_info.value.status_code == 404
+
+
+def test_create_tarjeta_api_error_propagates():
+    """create_tarjeta propagates APIError as HTTPException."""
+    from app.schemas.tarjeta import TarjetaCreate
+    from app.services.tarjetas import create_tarjeta
+
+    mock_client = MagicMock()
+    mock_client.table.return_value.insert.return_value.execute.side_effect = APIError(
+        {"code": "400", "message": "Bad request"}
+    )
+
+    data = TarjetaCreate(
+        banco="BPD",
+        titular="Test",
+        ultimos_digitos="1234",
+        tipo="credito",
+        red="visa",
+    )
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            create_tarjeta("fake-jwt", "u1", data)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_get_tarjetas_api_error_raises_500():
+    """get_tarjetas raises HTTP 500 on unexpected Supabase APIError."""
+    from app.services.tarjetas import get_tarjetas
+
+    mock_client = MagicMock()
+    (
+        mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.execute.side_effect
+    ) = APIError({"code": "503", "message": "Service unavailable"})
+
+    with patch("app.services.tarjetas.get_user_client", return_value=mock_client):
+        with pytest.raises(HTTPException) as exc_info:
+            get_tarjetas("fake-jwt", "u1")
+
+    assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# _enrich_tarjeta unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichTarjeta:
+    def test_credito_with_limite_computes_disponible(self) -> None:
+        from app.services.tarjetas import _enrich_tarjeta
+
+        row = {"tipo": "credito", "limite_credito": "50000.00", "saldo_actual": "15000.00"}
+        result = _enrich_tarjeta(row)
+        assert result["disponible"] == 35000.0
+
+    def test_credito_without_limite_disponible_is_none(self) -> None:
+        from app.services.tarjetas import _enrich_tarjeta
+
+        row = {"tipo": "credito", "limite_credito": None, "saldo_actual": "500.00"}
+        result = _enrich_tarjeta(row)
+        assert result["disponible"] is None
+
+    def test_debito_disponible_is_none(self) -> None:
+        from app.services.tarjetas import _enrich_tarjeta
+
+        row = {"tipo": "debito", "limite_credito": None, "saldo_actual": "10000.00"}
+        result = _enrich_tarjeta(row)
+        assert result["disponible"] is None
+
+    def test_credito_zero_saldo_disponible_equals_limite(self) -> None:
+        from app.services.tarjetas import _enrich_tarjeta
+
+        row = {"tipo": "credito", "limite_credito": "20000.00", "saldo_actual": "0"}
+        result = _enrich_tarjeta(row)
+        assert result["disponible"] == 20000.0

--- a/supabase/migrations/20260317000003_tarjetas.sql
+++ b/supabase/migrations/20260317000003_tarjetas.sql
@@ -1,0 +1,30 @@
+CREATE TABLE tarjetas (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  banco TEXT NOT NULL,
+  titular TEXT NOT NULL,
+  ultimos_digitos TEXT NOT NULL CHECK (char_length(ultimos_digitos) = 4),
+  tipo TEXT NOT NULL CHECK (tipo IN ('credito', 'debito')),
+  red TEXT NOT NULL CHECK (red IN ('visa', 'mastercard', 'amex', 'otra')),
+  limite_credito NUMERIC(12,2),   -- NULL para debito
+  saldo_actual NUMERIC(12,2) DEFAULT 0,  -- deuda actual en credito / saldo en debito
+  fecha_corte INTEGER,            -- dia del mes (1-31), NULL para debito
+  fecha_pago INTEGER,             -- dia del mes para pago, NULL para debito
+  color TEXT DEFAULT 'azul',      -- 'azul' | 'morado' | 'verde' | 'naranja'
+  activa BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE tarjetas ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own tarjetas" ON tarjetas FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert own tarjetas" ON tarjetas FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update own tarjetas" ON tarjetas FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete own tarjetas" ON tarjetas FOR DELETE USING (auth.uid() = user_id);
+
+CREATE TRIGGER update_tarjetas_updated_at BEFORE UPDATE ON tarjetas
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX idx_tarjetas_user_id ON tarjetas(user_id);
+CREATE INDEX idx_tarjetas_activa ON tarjetas(user_id, activa);


### PR DESCRIPTION
## Summary
- Adds `tarjetas` table migration with RLS policies and updated_at trigger
- Implements full CRUD service layer (`get_tarjetas`, `get_tarjeta`, `create_tarjeta`, `update_tarjeta`, `delete_tarjeta`) with computed `disponible` field for credit cards
- Adds 5 REST endpoints under `/api/v1/tarjetas` with auth guards
- Registers router in `api/v1/router.py`

## Changes
- `supabase/migrations/20260317000003_tarjetas.sql` — table + RLS + indexes
- `backend/app/schemas/tarjeta.py` — `TarjetaCreate`, `TarjetaUpdate`, `TarjetaResponse` with Pydantic v2 validators
- `backend/app/services/tarjetas.py` — service layer following prestamos/metas pattern
- `backend/app/api/v1/routes/tarjetas.py` — GET/POST/PUT/DELETE endpoints
- `backend/app/api/v1/router.py` — include tarjetas_router
- `backend/tests/test_tarjetas.py` — 17 tests covering happy paths, auth guards, validation, error cases

## Tests
- 5 auth guard tests (no token → 403)
- 6 schema validation tests (invalid digitos, tipo, red, negative saldo, zero limite)
- 6 service unit tests (create credito/debito, get list, get not found, update saldo, delete)
- 4 `_enrich_tarjeta` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)