### PR TITLE
feat(dashboard): month selector + PrediccionMesCard + sidebar toggle button

### DIFF
--- a/frontend/src/components/shared/Sidebar.tsx
+++ b/frontend/src/components/shared/Sidebar.tsx
@@ -82,25 +82,34 @@ export function Sidebar(): JSX.Element {
       >
         {/* Logo area */}
         <div
-          className={cn(
-            'flex items-center h-16',
-            sidebarCollapsed ? 'justify-center px-4' : 'px-5 justify-between'
-          )}
+          className="flex items-center h-16 px-3 justify-between"
           style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}
         >
-          {!sidebarCollapsed && (
-            <div className="flex items-center gap-2.5">
-              <div
-                className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 shadow-lg"
-                style={{
-                  background: 'linear-gradient(135deg, #5B9BD5, #366092)',
-                  boxShadow: '0 0 16px rgba(91,155,213,0.4)',
-                }}
-              >
-                <span className="font-bold text-white text-sm">F</span>
-              </div>
+          {/* Logo — clickeable para expandir cuando colapsado */}
+          <button
+            type="button"
+            onClick={() => sidebarCollapsed && setSidebarCollapsed(false)}
+            className={cn(
+              'flex items-center gap-2.5 min-w-0',
+              sidebarCollapsed ? 'cursor-pointer' : 'cursor-default pointer-events-none'
+            )}
+            aria-label={sidebarCollapsed ? 'Expandir sidebar' : undefined}
+            tabIndex={sidebarCollapsed ? 0 : -1}
+          >
+            <div
+              className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 shadow-lg"
+              style={{
+                background: 'linear-gradient(135deg, #5B9BD5, #366092)',
+                boxShadow: sidebarCollapsed
+                  ? '0 0 16px rgba(91,155,213,0.35)'
+                  : '0 0 16px rgba(91,155,213,0.4)',
+              }}
+            >
+              <span className="font-bold text-white text-sm">F</span>
+            </div>
+            {!sidebarCollapsed && (
               <span
-                className="font-bold text-lg tracking-tight"
+                className="font-bold text-lg tracking-tight truncate"
                 style={{
                   background: 'linear-gradient(135deg, #ffffff, #a0b4cc)',
                   WebkitBackgroundClip: 'text',
@@ -110,51 +119,36 @@ export function Sidebar(): JSX.Element {
               >
                 Finza
               </span>
-            </div>
-          )}
-          {sidebarCollapsed && (
-            <div
-              className="w-8 h-8 rounded-lg flex items-center justify-center shadow-lg"
-              style={{
-                background: 'linear-gradient(135deg, #5B9BD5, #366092)',
-                boxShadow: '0 0 16px rgba(91,155,213,0.35)',
-              }}
-            >
-              <span className="font-bold text-white text-sm">F</span>
-            </div>
-          )}
-
-          {/* Mobile close */}
-          <button
-            onClick={() => setSidebarOpen(false)}
-            className="lg:hidden text-white/50 hover:text-white transition-colors"
-            aria-label="Cerrar menu"
-          >
-            <X size={18} />
+            )}
           </button>
 
-          {/* Desktop collapse toggle */}
-          {!sidebarCollapsed && (
+          {/* Right side: mobile close OR desktop toggle */}
+          <div className="flex items-center gap-1 shrink-0">
+            {/* Mobile close */}
             <button
-              onClick={() => setSidebarCollapsed(true)}
-              className="hidden lg:flex text-white/30 hover:text-white/80 transition-colors w-7 h-7 items-center justify-center rounded-lg hover:bg-white/10"
-              aria-label="Colapsar sidebar"
+              onClick={() => setSidebarOpen(false)}
+              className="lg:hidden text-white/50 hover:text-white transition-colors p-1"
+              aria-label="Cerrar menu"
             >
-              <ChevronLeft size={16} />
+              <X size={18} />
             </button>
-          )}
-        </div>
 
-        {/* Expand button when collapsed */}
-        {sidebarCollapsed && (
-          <button
-            onClick={() => setSidebarCollapsed(false)}
-            className="hidden lg:flex items-center justify-center h-8 mx-3 mt-2 rounded-lg text-white/30 hover:text-white/80 hover:bg-white/10 transition-all duration-150"
-            aria-label="Expandir sidebar"
-          >
-            <ChevronRight size={15} />
-          </button>
-        )}
+            {/* Desktop collapse/expand toggle — always visible on desktop */}
+            <button
+              onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+              className="hidden lg:flex items-center justify-center text-white/30 hover:text-white/80 transition-all duration-150 hover:bg-white/10 rounded-[7px]"
+              style={{ width: 26, height: 26 }}
+              aria-label={sidebarCollapsed ? 'Expandir sidebar' : 'Colapsar sidebar'}
+              title={sidebarCollapsed ? 'Expandir sidebar' : 'Colapsar sidebar'}
+            >
+              {sidebarCollapsed ? (
+                <ChevronRight size={15} />
+              ) : (
+                <ChevronLeft size={15} />
+              )}
+            </button>
+          </div>
+        </div>
 
         {/* Navigation */}
         <nav className="flex-1 px-2 py-3 overflow-y-auto overflow-x-hidden">

--- a/frontend/src/components/shared/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/shared/__tests__/Sidebar.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { Sidebar } from '@/components/shared/Sidebar'
+
+// Mock stores
+const mockSetSidebarCollapsed = vi.fn()
+const mockSetSidebarOpen = vi.fn()
+const mockSignOut = vi.fn()
+
+vi.mock('@/store/uiStore', () => ({
+  useUiStore: vi.fn(),
+}))
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: vi.fn(),
+}))
+
+vi.mock('@/components/shared/ScoreWidget', () => ({
+  ScoreWidget: () => <div data-testid="score-widget" />,
+}))
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ name }: { name: string }) => <div data-testid="avatar">{name}</div>,
+}))
+
+import { useUiStore } from '@/store/uiStore'
+import { useAuthStore } from '@/store/authStore'
+
+function setupMocks({
+  sidebarCollapsed = false,
+  sidebarOpen = true,
+}: {
+  sidebarCollapsed?: boolean
+  sidebarOpen?: boolean
+} = {}) {
+  vi.mocked(useUiStore).mockReturnValue({
+    sidebarOpen,
+    setSidebarOpen: mockSetSidebarOpen,
+    sidebarCollapsed,
+    setSidebarCollapsed: mockSetSidebarCollapsed,
+  } as ReturnType<typeof useUiStore>)
+
+  vi.mocked(useAuthStore).mockReturnValue({
+    user: { email: 'test@example.com', user_metadata: { full_name: 'Test User' } },
+    signOut: mockSignOut,
+  } as unknown as ReturnType<typeof useAuthStore>)
+}
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <Sidebar />
+    </MemoryRouter>
+  )
+}
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders correctly with default props', () => {
+    renderSidebar()
+    expect(screen.getByText('Finza')).toBeInTheDocument()
+  })
+
+  it('shows logo text when expanded', () => {
+    setupMocks({ sidebarCollapsed: false })
+    renderSidebar()
+    expect(screen.getByText('Finza')).toBeInTheDocument()
+  })
+
+  it('hides logo text when collapsed', () => {
+    setupMocks({ sidebarCollapsed: true })
+    renderSidebar()
+    expect(screen.queryByText('Finza')).not.toBeInTheDocument()
+  })
+
+  it('shows desktop toggle button at all times', () => {
+    renderSidebar()
+    const toggleBtn = screen.getByTitle('Colapsar sidebar')
+    expect(toggleBtn).toBeInTheDocument()
+  })
+
+  it('toggle button collapses sidebar when expanded', () => {
+    setupMocks({ sidebarCollapsed: false })
+    renderSidebar()
+    const toggleBtn = screen.getByTitle('Colapsar sidebar')
+    fireEvent.click(toggleBtn)
+    expect(mockSetSidebarCollapsed).toHaveBeenCalledWith(true)
+  })
+
+  it('toggle button expands sidebar when collapsed', () => {
+    setupMocks({ sidebarCollapsed: true })
+    renderSidebar()
+    const toggleBtn = screen.getByTitle('Expandir sidebar')
+    fireEvent.click(toggleBtn)
+    expect(mockSetSidebarCollapsed).toHaveBeenCalledWith(false)
+  })
+
+  it('logo button expands sidebar when collapsed', () => {
+    setupMocks({ sidebarCollapsed: true })
+    renderSidebar()
+    // When collapsed there are two "Expandir sidebar" buttons: logo (type=button) and toggle
+    // The logo button is the one with type="button" explicitly set
+    const logoBtns = screen.getAllByLabelText('Expandir sidebar')
+    // Logo button is the first one (has type="button" and contains the F icon)
+    const logoBtn = logoBtns.find((el) => el.getAttribute('type') === 'button') as HTMLElement
+    fireEvent.click(logoBtn)
+    expect(mockSetSidebarCollapsed).toHaveBeenCalledWith(false)
+  })
+
+  it('logo button does not call setSidebarCollapsed when expanded', () => {
+    setupMocks({ sidebarCollapsed: false })
+    renderSidebar()
+    // When expanded the logo button has tabIndex=-1 and no aria-label
+    const fIcon = screen.getByText('F').closest('button')
+    if (fIcon) fireEvent.click(fIcon)
+    expect(mockSetSidebarCollapsed).not.toHaveBeenCalled()
+  })
+
+  it('shows mobile close button on mobile overlay', () => {
+    renderSidebar()
+    const closeBtn = screen.getByLabelText('Cerrar menu')
+    expect(closeBtn).toBeInTheDocument()
+  })
+
+  it('calls setSidebarOpen(false) when mobile close button is clicked', () => {
+    renderSidebar()
+    const closeBtn = screen.getByLabelText('Cerrar menu')
+    fireEvent.click(closeBtn)
+    expect(mockSetSidebarOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('renders nav items', () => {
+    renderSidebar()
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Ingresos')).toBeInTheDocument()
+    expect(screen.getByText('Egresos')).toBeInTheDocument()
+  })
+
+  it('renders user name in user section', () => {
+    renderSidebar()
+    expect(screen.getAllByText('Test User').length).toBeGreaterThan(0)
+  })
+
+  it('calls signOut and navigates on logout click', () => {
+    renderSidebar()
+    const logoutBtn = screen.getByLabelText('Cerrar sesion')
+    fireEvent.click(logoutBtn)
+    expect(mockSignOut).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- **Sidebar**: toggle button movido al lado del logo (inline, 26x26px, border-radius 7px). El botón de expandir separado fue eliminado. Cuando el sidebar está colapsado, hacer clic en el logo lo expande.
- **Dashboard mes selector**: ya estaba implementado con pill buttons (Ene-Dic) y select de año — no requirió cambios.
- **PrediccionMesCard**: el hook `usePrediccionMes` y el componente `PrediccionMesCard` ya existían e integrados en DashboardPage — no requirió cambios.

## Changes

- `frontend/src/components/shared/Sidebar.tsx`: refactor de logo area — toggle único siempre visible inline, logo clickeable para expandir cuando colapsado
- `frontend/src/components/shared/__tests__/Sidebar.test.tsx`: nuevo archivo con 13 tests cubriendo collapse, expand, logo click, mobile close, nav items, user section

## Tests

- 13 tests Sidebar.test.tsx — 13 passing
- 21 tests DashboardPage.test.tsx — 21 passing (regresion)

## Edge Cases Covered

- Toggle muestra ChevronRight cuando colapsado, ChevronLeft cuando expandido
- Logo button tiene `tabIndex={-1}` y `pointer-events-none` cuando expandido (no intercepta clics accidentales)
- En mobile, el botón de cerrar (X) permanece separado y funcional