### PR TITLE
feat(ui): add premium visual components — stats bar, cursor glow, blobs, command palette, mobile nav

### DIFF
--- a/frontend/src/components/shared/BottomNav.tsx
+++ b/frontend/src/components/shared/BottomNav.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react'
+import { NavLink, useNavigate } from 'react-router-dom'
+import { BarChart3, TrendingUp, TrendingDown, Target, Plus, X, HandCoins, PiggyBank, CreditCard } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface QuickAction {
+  id: string
+  label: string
+  icon: JSX.Element
+  path: string
+  color: string
+}
+
+const QUICK_ACTIONS: QuickAction[] = [
+  {
+    id: 'ingresos',
+    label: 'Nuevo ingreso',
+    icon: <TrendingUp size={18} />,
+    path: '/ingresos',
+    color: 'bg-emerald-500',
+  },
+  {
+    id: 'egresos',
+    label: 'Nuevo egreso',
+    icon: <TrendingDown size={18} />,
+    path: '/egresos',
+    color: 'bg-red-500',
+  },
+  {
+    id: 'prestamos',
+    label: 'Nuevo prestamo',
+    icon: <HandCoins size={18} />,
+    path: '/prestamos',
+    color: 'bg-amber-500',
+  },
+  {
+    id: 'tarjetas',
+    label: 'Tarjetas',
+    icon: <CreditCard size={18} />,
+    path: '/tarjetas',
+    color: 'bg-indigo-500',
+  },
+]
+
+const NAV_ITEMS = [
+  { to: '/', icon: <BarChart3 size={22} />, label: 'Dashboard', end: true },
+  { to: '/ingresos', icon: <TrendingUp size={22} />, label: 'Ingresos', end: false },
+  { to: '/egresos', icon: <TrendingDown size={22} />, label: 'Egresos', end: false },
+  { to: '/metas', icon: <PiggyBank size={22} />, label: 'Metas', end: false },
+]
+
+function QuickActionSheet({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean
+  onClose: () => void
+}): JSX.Element | null {
+  const navigate = useNavigate()
+  if (!isOpen) return null
+
+  const handleAction = (path: string) => {
+    navigate(path)
+    onClose()
+  }
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40"
+        style={{ background: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(4px)' }}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        className={cn(
+          'fixed bottom-20 left-1/2 -translate-x-1/2 z-50',
+          'bg-[var(--surface)] border border-[var(--border)] rounded-2xl',
+          'p-4 w-72 shadow-2xl animate-slide-up'
+        )}
+        role="dialog"
+        aria-label="Acciones rapidas"
+      >
+        <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wide mb-3">
+          Acciones rapidas
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          {QUICK_ACTIONS.map((action) => (
+            <button
+              key={action.id}
+              onClick={() => handleAction(action.path)}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2.5 rounded-xl text-white text-sm font-medium',
+                'transition-all duration-150 active:scale-95',
+                action.color
+              )}
+            >
+              {action.icon}
+              <span>{action.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export function BottomNav(): JSX.Element {
+  const [sheetOpen, setSheetOpen] = useState(false)
+
+  return (
+    <>
+      <QuickActionSheet isOpen={sheetOpen} onClose={() => setSheetOpen(false)} />
+
+      <nav
+        className="md:hidden fixed bottom-0 left-0 right-0 z-30 h-16 flex items-center justify-around px-2"
+        style={{
+          backdropFilter: 'blur(20px)',
+          WebkitBackdropFilter: 'blur(20px)',
+          background: 'rgba(255,255,255,0.95)',
+          borderTop: '1px solid rgba(0,0,0,0.08)',
+        }}
+        aria-label="Navegacion principal"
+      >
+        {/* First two items */}
+        {NAV_ITEMS.slice(0, 2).map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            aria-label={item.label}
+            className={({ isActive }) =>
+              cn(
+                'flex flex-col items-center gap-0.5 px-3 py-1 rounded-xl transition-all duration-150',
+                isActive ? 'text-[var(--accent)]' : 'text-[var(--text-muted)]'
+              )
+            }
+          >
+            {({ isActive }) => (
+              <>
+                <span className={cn('transition-transform duration-150', isActive ? 'scale-110' : '')}>
+                  {item.icon}
+                </span>
+                <span className="text-[10px] font-medium leading-none">{item.label}</span>
+              </>
+            )}
+          </NavLink>
+        ))}
+
+        {/* FAB center */}
+        <button
+          onClick={() => setSheetOpen((v) => !v)}
+          className={cn(
+            'relative flex items-center justify-center w-14 h-14 rounded-full shadow-lg',
+            'transition-all duration-200 active:scale-90',
+            '-mt-8'
+          )}
+          style={{
+            background: 'linear-gradient(135deg, #366092, #818cf8)',
+            boxShadow: '0 4px 20px rgba(54,96,146,0.45)',
+          }}
+          aria-label={sheetOpen ? 'Cerrar acciones rapidas' : 'Abrir acciones rapidas'}
+          aria-expanded={sheetOpen}
+        >
+          <span
+            className={cn(
+              'transition-transform duration-200',
+              sheetOpen ? 'rotate-45' : 'rotate-0'
+            )}
+          >
+            {sheetOpen ? <X size={22} color="white" /> : <Plus size={22} color="white" />}
+          </span>
+        </button>
+
+        {/* Last two items */}
+        {NAV_ITEMS.slice(2).map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            aria-label={item.label}
+            className={({ isActive }) =>
+              cn(
+                'flex flex-col items-center gap-0.5 px-3 py-1 rounded-xl transition-all duration-150',
+                isActive ? 'text-[var(--accent)]' : 'text-[var(--text-muted)]'
+              )
+            }
+          >
+            {({ isActive }) => (
+              <>
+                <span className={cn('transition-transform duration-150', isActive ? 'scale-110' : '')}>
+                  {item.icon}
+                </span>
+                <span className="text-[10px] font-medium leading-none">{item.label}</span>
+              </>
+            )}
+          </NavLink>
+        ))}
+
+        {/* Presupuestos as last visible item */}
+        <NavLink
+          to="/presupuestos"
+          aria-label="Presupuestos"
+          className={({ isActive }) =>
+            cn(
+              'flex flex-col items-center gap-0.5 px-3 py-1 rounded-xl transition-all duration-150',
+              isActive ? 'text-[var(--accent)]' : 'text-[var(--text-muted)]'
+            )
+          }
+        >
+          {({ isActive }) => (
+            <>
+              <span className={cn('transition-transform duration-150', isActive ? 'scale-110' : '')}>
+                <Target size={22} />
+              </span>
+              <span className="text-[10px] font-medium leading-none">Presupuestos</span>
+            </>
+          )}
+        </NavLink>
+      </nav>
+
+      {/* Dark mode bottom nav */}
+      <style>{`
+        @media (max-width: 767px) {
+          .dark nav[aria-label="Navegacion principal"] {
+            background: rgba(4,8,15,0.95) !important;
+            border-top-color: rgba(255,255,255,0.06) !important;
+          }
+        }
+      `}</style>
+    </>
+  )
+}

--- a/frontend/src/components/shared/CommandPalette.tsx
+++ b/frontend/src/components/shared/CommandPalette.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Search } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface Command {
+  id: string
+  label: string
+  icon: string
+  path: string
+}
+
+const COMMANDS: Command[] = [
+  { id: 'dashboard', label: 'Ir a Dashboard', icon: '📊', path: '/' },
+  { id: 'ingresos', label: 'Ir a Ingresos', icon: '💰', path: '/ingresos' },
+  { id: 'egresos', label: 'Ir a Egresos', icon: '💸', path: '/egresos' },
+  { id: 'presupuestos', label: 'Ir a Presupuestos', icon: '📋', path: '/presupuestos' },
+  { id: 'prestamos', label: 'Ir a Préstamos', icon: '🏦', path: '/prestamos' },
+  { id: 'metas', label: 'Ir a Metas', icon: '🎯', path: '/metas' },
+  { id: 'tarjetas', label: 'Ir a Tarjetas', icon: '💳', path: '/tarjetas' },
+  { id: 'recurrentes', label: 'Ir a Recurrentes', icon: '🔄', path: '/recurrentes' },
+  { id: 'categorias', label: 'Ir a Categorias', icon: '🏷️', path: '/categorias' },
+  { id: 'configuracion', label: 'Configuracion', icon: '⚙️', path: '/configuracion' },
+]
+
+interface CommandPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function CommandPalette({ isOpen, onClose }: CommandPaletteProps): JSX.Element | null {
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const navigate = useNavigate()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  const filtered = query.trim()
+    ? COMMANDS.filter((c) => c.label.toLowerCase().includes(query.toLowerCase()))
+    : COMMANDS
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('')
+      setActiveIndex(0)
+      setTimeout(() => inputRef.current?.focus(), 50)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [query])
+
+  const execute = (command: Command) => {
+    navigate(command.path)
+    onClose()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose()
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.min(i + 1, filtered.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (filtered[activeIndex]) execute(filtered[activeIndex])
+    }
+  }
+
+  useEffect(() => {
+    if (!listRef.current) return
+    const activeEl = listRef.current.children[activeIndex] as HTMLElement | undefined
+    activeEl?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] px-4"
+      style={{ background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(4px)' }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div
+        className={cn(
+          'w-full max-w-lg rounded-2xl border border-[var(--border-strong)] overflow-hidden',
+          'bg-[var(--surface)] shadow-2xl animate-slide-up'
+        )}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--border)]">
+          <Search size={16} className="text-[var(--text-muted)] shrink-0" aria-hidden="true" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Buscar pagina o accion..."
+            className={cn(
+              'flex-1 bg-transparent text-[var(--text-primary)] text-sm placeholder:text-[var(--text-subtle)]',
+              'outline-none'
+            )}
+            aria-label="Buscar comando"
+            aria-autocomplete="list"
+            aria-controls="command-list"
+            aria-activedescendant={filtered[activeIndex] ? `cmd-${filtered[activeIndex].id}` : undefined}
+          />
+          <kbd
+            className={cn(
+              'text-[10px] font-mono px-1.5 py-0.5 rounded',
+              'bg-[var(--surface-raised)] border border-[var(--border)] text-[var(--text-muted)]'
+            )}
+          >
+            ESC
+          </kbd>
+        </div>
+
+        {/* Command list */}
+        <ul
+          id="command-list"
+          ref={listRef}
+          className="max-h-72 overflow-y-auto py-1"
+          role="listbox"
+          aria-label="Comandos disponibles"
+        >
+          {filtered.length === 0 && (
+            <li className="px-4 py-3 text-sm text-[var(--text-muted)] text-center">
+              Sin resultados para &quot;{query}&quot;
+            </li>
+          )}
+          {filtered.map((cmd, i) => (
+            <li
+              key={cmd.id}
+              id={`cmd-${cmd.id}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              className={cn(
+                'flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors duration-100',
+                i === activeIndex
+                  ? 'bg-[var(--accent-muted)] text-[var(--text-primary)]'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--surface-raised)]'
+              )}
+              onClick={() => execute(cmd)}
+              onMouseEnter={() => setActiveIndex(i)}
+            >
+              <span className="text-base leading-none" aria-hidden="true">{cmd.icon}</span>
+              <span className="text-sm font-medium flex-1">{cmd.label}</span>
+              {i === activeIndex && (
+                <kbd
+                  className={cn(
+                    'text-[10px] font-mono px-1.5 py-0.5 rounded',
+                    'bg-[var(--surface)] border border-[var(--border)] text-[var(--text-muted)]'
+                  )}
+                >
+                  Enter
+                </kbd>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {/* Footer */}
+        <div
+          className={cn(
+            'flex items-center gap-4 px-4 py-2 border-t border-[var(--border)]',
+            'text-[10px] text-[var(--text-subtle)]'
+          )}
+        >
+          <span><kbd className="font-mono">↑↓</kbd> navegar</span>
+          <span><kbd className="font-mono">Enter</kbd> seleccionar</span>
+          <span><kbd className="font-mono">ESC</kbd> cerrar</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/Layout.tsx
+++ b/frontend/src/components/shared/Layout.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import { Sidebar } from './Sidebar'
 import { Header } from './Header'
+import { StatsBar } from './StatsBar'
+import { CommandPalette } from './CommandPalette'
+import { BottomNav } from './BottomNav'
 import { useUiStore } from '@/store/uiStore'
 import { useProfile } from '@/hooks/useProfile'
 import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard'
@@ -11,6 +14,7 @@ export function Layout(): JSX.Element {
   const { sidebarCollapsed } = useUiStore()
   const { data: profile } = useProfile()
   const [showOnboarding, setShowOnboarding] = useState(false)
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
 
   useEffect(() => {
     if (profile && profile.onboarding_completed === false) {
@@ -18,22 +22,66 @@ export function Layout(): JSX.Element {
     }
   }, [profile])
 
+  // Cursor glow mouse handler
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      document.documentElement.style.setProperty('--cx', `${e.clientX}px`)
+      document.documentElement.style.setProperty('--cy', `${e.clientY}px`)
+    }
+    window.addEventListener('mousemove', handler, { passive: true })
+    return () => window.removeEventListener('mousemove', handler)
+  }, [])
+
+  // Ctrl/Cmd+K command palette
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault()
+        setCommandPaletteOpen((prev) => !prev)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background relative">
+      {/* Cursor glow — dark mode only via CSS .dark selector */}
+      <div id="cursor-glow" aria-hidden="true" />
+
+      {/* Ambient blobs — dark mode only */}
+      <div
+        className="dark:block hidden pointer-events-none fixed inset-0 overflow-hidden z-0"
+        aria-hidden="true"
+      >
+        <div className="blob blob-1" />
+        <div className="blob blob-2" />
+        <div className="blob blob-3" />
+      </div>
+
       <Sidebar />
+
       <div
         className={cn(
-          'flex flex-col min-h-screen transition-all duration-300',
+          'flex flex-col min-h-screen transition-all duration-300 relative z-10',
           sidebarCollapsed ? 'lg:ml-[72px]' : 'lg:ml-64'
         )}
       >
         <Header />
-        <main className="flex-1 p-6">
+        <StatsBar onCommandPaletteOpen={() => setCommandPaletteOpen(true)} />
+        <main className="flex-1 p-6 pb-20 md:pb-6">
           <div className="animate-fade-in">
             <Outlet />
           </div>
         </main>
+        <BottomNav />
       </div>
+
+      <CommandPalette
+        isOpen={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
+      />
+
       {showOnboarding && (
         <OnboardingWizard onComplete={() => setShowOnboarding(false)} />
       )}

--- a/frontend/src/components/shared/StatsBar.tsx
+++ b/frontend/src/components/shared/StatsBar.tsx
@@ -1,0 +1,161 @@
+import { useNavigate } from 'react-router-dom'
+import { useDashboardV2 } from '@/hooks/useDashboardV2'
+import { cn } from '@/lib/utils'
+
+interface StatItemProps {
+  label: string
+  value: string
+  badge?: string
+  badgeVariant?: 'positive' | 'negative' | 'warning' | 'neutral'
+}
+
+function StatItem({ label, value, badge, badgeVariant = 'neutral' }: StatItemProps): JSX.Element {
+  const badgeClass = {
+    positive: 'text-emerald-400 bg-emerald-400/10',
+    negative: 'text-red-400 bg-red-400/10',
+    warning: 'text-amber-400 bg-amber-400/10',
+    neutral: 'text-[var(--text-muted)] bg-[var(--surface-raised)]',
+  }[badgeVariant]
+
+  return (
+    <div className="flex items-center gap-2 px-3 shrink-0">
+      <div className="flex flex-col">
+        <span className="text-[10px] font-medium text-[var(--text-subtle)] uppercase tracking-wide leading-none mb-0.5">
+          {label}
+        </span>
+        <span className="text-sm font-bold tabular-nums text-[var(--text-primary)] leading-none">
+          {value}
+        </span>
+      </div>
+      {badge && (
+        <span className={cn('text-[10px] font-semibold px-1.5 py-0.5 rounded-full', badgeClass)}>
+          {badge}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function StatDivider(): JSX.Element {
+  return <div className="w-px h-6 bg-[var(--border)] shrink-0" aria-hidden="true" />
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+function formatPct(value: number): string {
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${value.toFixed(1)}%`
+}
+
+function getBadgeVariant(value: number, invert = false): 'positive' | 'negative' | 'warning' {
+  if (Math.abs(value) < 3) return 'warning'
+  const isPositive = value > 0
+  return (invert ? !isPositive : isPositive) ? 'positive' : 'negative'
+}
+
+interface StatsBarProps {
+  onCommandPaletteOpen: () => void
+}
+
+export function StatsBar({ onCommandPaletteOpen }: StatsBarProps): JSX.Element {
+  const now = new Date()
+  const { data, isLoading } = useDashboardV2({ mes: now.getMonth() + 1, year: now.getFullYear() })
+  const navigate = useNavigate()
+
+  if (isLoading || !data) {
+    return (
+      <div
+        className="statsbar-glass hidden md:flex items-center gap-6 h-11 px-4 sticky top-16 z-40 border-b border-[var(--border)]"
+        style={{
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+          background: 'rgba(255,255,255,0.85)',
+        }}
+      >
+        {[80, 100, 90, 70, 95].map((w, i) => (
+          <div key={i} className="h-3 rounded shimmer" style={{ width: `${w}px` }} />
+        ))}
+      </div>
+    )
+  }
+
+  const { resumen_financiero: rf, prestamos_activos: pa } = data
+  const balance = rf.ingresos_mes - rf.egresos_mes
+
+  const proximoVencimiento = pa.proximo_vencimiento
+    ? new Date(pa.proximo_vencimiento).toLocaleDateString('es-MX', { day: '2-digit', month: 'short' })
+    : '—'
+
+  return (
+    <div
+      className="statsbar-glass hidden md:flex items-center h-11 px-4 sticky top-16 z-40 border-b border-[var(--border)]"
+      style={{
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
+        background: 'rgba(255,255,255,0.85)',
+      }}
+    >
+      <div className="flex items-center gap-1 flex-1 overflow-x-auto scrollbar-none">
+        <StatItem
+          label="Balance"
+          value={formatCurrency(balance)}
+          badge={formatPct(rf.tasa_ahorro)}
+          badgeVariant={rf.tasa_ahorro > 0 ? 'positive' : rf.tasa_ahorro < -5 ? 'negative' : 'warning'}
+        />
+        <StatDivider />
+        <StatItem
+          label="Ingresos"
+          value={formatCurrency(rf.ingresos_mes)}
+          badge={formatPct(rf.variacion_ingresos_pct)}
+          badgeVariant={getBadgeVariant(rf.variacion_ingresos_pct)}
+        />
+        <StatDivider />
+        <StatItem
+          label="Egresos"
+          value={formatCurrency(rf.egresos_mes)}
+          badge={formatPct(rf.variacion_egresos_pct)}
+          badgeVariant={getBadgeVariant(rf.variacion_egresos_pct, true)}
+        />
+        <StatDivider />
+        <button
+          onClick={() => navigate('/prestamos')}
+          className="flex items-center px-3 hover:opacity-80 transition-opacity"
+          aria-label="Ver préstamos"
+        >
+          <div className="flex flex-col">
+            <span className="text-[10px] font-medium text-[var(--text-subtle)] uppercase tracking-wide leading-none mb-0.5">
+              Prox. Venc.
+            </span>
+            <span className="text-sm font-bold tabular-nums text-[var(--text-primary)] leading-none">
+              {proximoVencimiento}
+            </span>
+          </div>
+        </button>
+      </div>
+
+      {/* Command palette trigger */}
+      <button
+        onClick={onCommandPaletteOpen}
+        className={cn(
+          'ml-4 shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium',
+          'text-[var(--text-muted)] bg-[var(--surface-raised)] border border-[var(--border)]',
+          'hover:text-[var(--text-primary)] hover:border-[var(--accent)] transition-all duration-150'
+        )}
+        aria-label="Abrir command palette"
+        title="Ctrl+K"
+      >
+        <span>Buscar</span>
+        <kbd className="text-[10px] font-mono bg-[var(--surface)] border border-[var(--border)] px-1 rounded">
+          Ctrl K
+        </kbd>
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/__tests__/BottomNav.test.tsx
+++ b/frontend/src/components/shared/__tests__/BottomNav.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BottomNav } from '@/components/shared/BottomNav'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  NavLink: ({ to, children, className, 'aria-label': ariaLabel }: {
+    to: string
+    children: (args: { isActive: boolean }) => React.ReactNode
+    className: (args: { isActive: boolean }) => string
+    'aria-label': string
+  }) => (
+    <a
+      href={to}
+      aria-label={ariaLabel}
+      className={className({ isActive: false })}
+      onClick={(e) => { e.preventDefault(); mockNavigate(to) }}
+    >
+      {typeof children === 'function' ? children({ isActive: false }) : children}
+    </a>
+  ),
+}))
+
+describe('BottomNav', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the nav element', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('navigation', { name: /navegacion principal/i })).toBeInTheDocument()
+  })
+
+  it('renders Dashboard nav link', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument()
+  })
+
+  it('renders Ingresos nav link', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('link', { name: /ingresos/i })).toBeInTheDocument()
+  })
+
+  it('renders Egresos nav link', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('link', { name: /egresos/i })).toBeInTheDocument()
+  })
+
+  it('renders FAB button', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('button', { name: /abrir acciones rapidas/i })).toBeInTheDocument()
+  })
+
+  it('opens quick action sheet when FAB is clicked', () => {
+    render(<BottomNav />)
+    const fab = screen.getByRole('button', { name: /abrir acciones rapidas/i })
+    fireEvent.click(fab)
+    expect(screen.getByRole('dialog', { name: /acciones rapidas/i })).toBeInTheDocument()
+  })
+
+  it('shows quick action items in sheet', () => {
+    render(<BottomNav />)
+    fireEvent.click(screen.getByRole('button', { name: /abrir acciones rapidas/i }))
+    expect(screen.getByText('Nuevo ingreso')).toBeInTheDocument()
+    expect(screen.getByText('Nuevo egreso')).toBeInTheDocument()
+  })
+
+  it('closes quick action sheet when backdrop is clicked', () => {
+    render(<BottomNav />)
+    fireEvent.click(screen.getByRole('button', { name: /abrir acciones rapidas/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    const backdrop = document.querySelector('[aria-hidden="true"]')!
+    fireEvent.click(backdrop)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('FAB aria-label changes when sheet is open', () => {
+    render(<BottomNav />)
+    const fab = screen.getByRole('button', { name: /abrir acciones rapidas/i })
+    fireEvent.click(fab)
+    expect(screen.getByRole('button', { name: /cerrar acciones rapidas/i })).toBeInTheDocument()
+  })
+
+  it('navigates to /ingresos when clicking quick action', () => {
+    render(<BottomNav />)
+    fireEvent.click(screen.getByRole('button', { name: /abrir acciones rapidas/i }))
+    fireEvent.click(screen.getByText('Nuevo ingreso'))
+    expect(mockNavigate).toHaveBeenCalledWith('/ingresos')
+  })
+
+  it('renders Presupuestos nav link', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('link', { name: /presupuestos/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/shared/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CommandPalette } from '@/components/shared/CommandPalette'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+// jsdom does not implement scrollIntoView
+Element.prototype.scrollIntoView = vi.fn()
+
+describe('CommandPalette', () => {
+  const onClose = vi.fn()
+
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(<CommandPalette isOpen={false} onClose={onClose} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders command list when isOpen is true', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Ir a Dashboard')).toBeInTheDocument()
+  })
+
+  it('renders all default commands', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    expect(screen.getByText('Ir a Ingresos')).toBeInTheDocument()
+    expect(screen.getByText('Ir a Egresos')).toBeInTheDocument()
+    expect(screen.getByText('Ir a Presupuestos')).toBeInTheDocument()
+    expect(screen.getByText('Ir a Tarjetas')).toBeInTheDocument()
+  })
+
+  it('filters commands based on search input', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    const input = screen.getByRole('textbox', { name: /buscar comando/i })
+    fireEvent.change(input, { target: { value: 'ingresos' } })
+    expect(screen.getByText('Ir a Ingresos')).toBeInTheDocument()
+    expect(screen.queryByText('Ir a Egresos')).not.toBeInTheDocument()
+  })
+
+  it('shows no-results message when query has no matches', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    const input = screen.getByRole('textbox', { name: /buscar comando/i })
+    fireEvent.change(input, { target: { value: 'xyznotfound' } })
+    expect(screen.getByText(/Sin resultados/)).toBeInTheDocument()
+  })
+
+  it('calls onClose when ESC key is pressed in the search input', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    // keyDown handler is on the inner modal div — events bubble from the input
+    const input = screen.getByRole('textbox', { name: /buscar comando/i })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    // The backdrop is the fixed overlay div (role=dialog wraps the visible modal)
+    const backdrop = document.querySelector('[role="dialog"]')!
+    fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('navigates and closes when a command is clicked', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Ir a Metas'))
+    expect(mockNavigate).toHaveBeenCalledWith('/metas')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('keyboard ArrowDown moves active index down', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    const dialog = screen.getByRole('dialog').querySelector('div')!
+    fireEvent.keyDown(dialog, { key: 'ArrowDown' })
+    // Second item (Ir a Ingresos) should now be aria-selected
+    const options = screen.getAllByRole('option')
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('keyboard ArrowUp does not go below index 0', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    const dialog = screen.getByRole('dialog').querySelector('div')!
+    fireEvent.keyDown(dialog, { key: 'ArrowUp' })
+    const options = screen.getAllByRole('option')
+    // First item remains selected
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('Enter executes the currently highlighted command', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    const dialog = screen.getByRole('dialog').querySelector('div')!
+    // Default first item is Dashboard
+    fireEvent.keyDown(dialog, { key: 'Enter' })
+    expect(mockNavigate).toHaveBeenCalledWith('/')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('renders keyboard hint footer', () => {
+    render(<CommandPalette isOpen={true} onClose={onClose} />)
+    expect(screen.getByText('navegar')).toBeInTheDocument()
+    expect(screen.getByText('seleccionar')).toBeInTheDocument()
+    expect(screen.getByText('cerrar')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/__tests__/StatsBar.test.tsx
+++ b/frontend/src/components/shared/__tests__/StatsBar.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StatsBar } from '@/components/shared/StatsBar'
+import type { DashboardV2Response } from '@/types/dashboard'
+
+vi.mock('@/hooks/useDashboardV2', () => ({ useDashboardV2: vi.fn() }))
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+import { useDashboardV2 } from '@/hooks/useDashboardV2'
+
+const mockData: DashboardV2Response = {
+  resumen_financiero: {
+    ingresos_mes: 50000,
+    egresos_mes: 35000,
+    balance_mes: 15000,
+    tasa_ahorro: 30,
+    ingresos_mes_anterior: 45000,
+    egresos_mes_anterior: 32000,
+    variacion_ingresos_pct: 11.1,
+    variacion_egresos_pct: 9.4,
+  },
+  presupuestos_estado: [],
+  metas_activas: [],
+  prestamos_activos: {
+    total_deuda: 100000,
+    count: 2,
+    proximo_vencimiento: '2026-04-15',
+  },
+  ultimas_transacciones: [],
+  egresos_por_categoria: [],
+}
+
+describe('StatsBar', () => {
+  const onOpen = vi.fn()
+
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders loading skeleton while fetching', () => {
+    vi.mocked(useDashboardV2).mockReturnValue({ data: undefined, isLoading: true } as ReturnType<typeof useDashboardV2>)
+    const { container } = render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    const shimmer = container.querySelector('.shimmer')
+    expect(shimmer).not.toBeNull()
+  })
+
+  it('renders stats when data is loaded', () => {
+    vi.mocked(useDashboardV2).mockReturnValue({ data: mockData, isLoading: false } as ReturnType<typeof useDashboardV2>)
+    render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    expect(screen.getByText('Balance')).toBeInTheDocument()
+    expect(screen.getByText('Ingresos')).toBeInTheDocument()
+    expect(screen.getByText('Egresos')).toBeInTheDocument()
+  })
+
+  it('renders proximo vencimiento label', () => {
+    vi.mocked(useDashboardV2).mockReturnValue({ data: mockData, isLoading: false } as ReturnType<typeof useDashboardV2>)
+    render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    expect(screen.getByText('Prox. Venc.')).toBeInTheDocument()
+  })
+
+  it('renders command palette trigger button', () => {
+    vi.mocked(useDashboardV2).mockReturnValue({ data: mockData, isLoading: false } as ReturnType<typeof useDashboardV2>)
+    render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    expect(screen.getByRole('button', { name: /abrir command palette/i })).toBeInTheDocument()
+  })
+
+  it('calls onCommandPaletteOpen when button is clicked', () => {
+    vi.mocked(useDashboardV2).mockReturnValue({ data: mockData, isLoading: false } as ReturnType<typeof useDashboardV2>)
+    render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    fireEvent.click(screen.getByRole('button', { name: /abrir command palette/i }))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders no stats bar when no data and not loading (null/undefined)', () => {
+    vi.mocked(useDashboardV2).mockReturnValue({ data: undefined, isLoading: false } as ReturnType<typeof useDashboardV2>)
+    const { container } = render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    // Should render skeleton (loading-like fallback) when data is null
+    expect(container.querySelector('.statsbar-glass')).not.toBeNull()
+  })
+
+  it('shows positive badge variant for positive tasa_ahorro', () => {
+    vi.mocked(useDashboardV2).mockReturnValue({ data: mockData, isLoading: false } as ReturnType<typeof useDashboardV2>)
+    const { container } = render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    // 30% savings rate — positive badge (emerald color)
+    const positiveBadge = container.querySelector('.text-emerald-400')
+    expect(positiveBadge).not.toBeNull()
+  })
+
+  it('shows dash when proximo_vencimiento is null', () => {
+    const dataNoVenc = {
+      ...mockData,
+      prestamos_activos: { ...mockData.prestamos_activos, proximo_vencimiento: null },
+    }
+    vi.mocked(useDashboardV2).mockReturnValue({ data: dataNoVenc, isLoading: false } as ReturnType<typeof useDashboardV2>)
+    render(<StatsBar onCommandPaletteOpen={onOpen} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -157,6 +157,66 @@
   }
 }
 
+/* ========== Cursor glow — dark only ========== */
+.dark #cursor-glow {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background: radial-gradient(
+    600px circle at var(--cx, 50%) var(--cy, 50%),
+    rgba(61, 142, 248, 0.07) 0%,
+    transparent 70%
+  );
+}
+
+/* ========== Ambient blobs — dark only ========== */
+.blob {
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(120px);
+  pointer-events: none;
+  opacity: 0.18;
+  animation: blobdrift 18s ease-in-out infinite alternate;
+}
+.blob-1 { width: 500px; height: 500px; background: #3d8ef8; top: -200px; left: -100px; animation-delay: 0s; }
+.blob-2 { width: 400px; height: 400px; background: #9768ff; top: 40%; right: -150px; animation-delay: -6s; }
+.blob-3 { width: 350px; height: 350px; background: #00dfff; bottom: -100px; left: 30%; animation-delay: -12s; }
+
+@keyframes blobdrift {
+  0%   { transform: translate(0, 0) scale(1); }
+  100% { transform: translate(40px, 30px) scale(1.1); }
+}
+
+/* ========== Dot grid — dark only ========== */
+.dark body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.13) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
+  -webkit-mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
+}
+
+/* ========== Film grain — dark only ========== */
+.dark body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* ========== StatsBar dark mode background ========== */
+.dark .statsbar-glass {
+  background: rgba(4, 8, 15, 0.85) !important;
+}
+
 @layer components {
   label {
     color: var(--text-secondary);


### PR DESCRIPTION
## Summary

- **StatsBar**: glass bar sticky below header showing balance, ingresos del mes, egresos del mes, tasa de ahorro badge y proximo vencimiento de prestamo. Trigger button for command palette on the right. Desktop-only (hidden on mobile). Data from useDashboardV2.
- **CommandPalette**: Ctrl/Cmd+K modal with fuzzy search over 10 navigation targets. Full keyboard navigation (ArrowUp/Down/Enter/ESC). Accessible with ARIA roles.
- **BottomNav**: Mobile-only (md:hidden) fixed bottom bar with 5 nav items + central FAB button. FAB opens a quick-action sheet for ingresos, egresos, prestamos, tarjetas.
- **Layout**: Integrated StatsBar, CommandPalette, BottomNav. Cursor glow handler and Ctrl+K keyboard handler. Ambient blob containers (dark only).
- **globals.css**: Cursor glow (dark only), ambient blobs blobdrift animation (dark only), dot grid radial pattern (dark only), film grain SVG texture (dark only), statsbar-glass dark override.

## Dark/Light mode

All visual effects (blobs, dot grid, film grain, cursor glow) are scoped to .dark prefix — fully inactive in light mode.

## Tests

31 new tests, all passing:
- StatsBar.test.tsx — 8 tests
- CommandPalette.test.tsx — 12 tests
- BottomNav.test.tsx — 11 tests

Pre-existing failure: PrestamosPage badge test (unrelated, was failing before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)