### PR TITLE
feat(ui): premium design system foundation — glassmorphism, tokens, login, sidebar

### DIFF
--- a/frontend/src/components/shared/Sidebar.tsx
+++ b/frontend/src/components/shared/Sidebar.tsx
@@ -46,6 +46,74 @@ const navItems = [
   { to: '/configuracion', icon: Settings, labelKey: 'nav.configuracion' },
 ]
 
+function NavItem({
+  to,
+  icon: Icon,
+  labelKey,
+  collapsed,
+}: {
+  to: string
+  icon: React.ElementType
+  labelKey: string
+  collapsed: boolean
+}): JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <NavLink
+      to={to}
+      end={to === '/'}
+      title={collapsed ? t(labelKey) : undefined}
+      className={({ isActive }) =>
+        cn(
+          'group relative flex items-center gap-3 rounded-xl mb-0.5 text-sm font-medium transition-all duration-150',
+          collapsed ? 'justify-center w-11 h-11 mx-auto' : 'px-3 py-2.5',
+          isActive
+            ? 'text-white sidebar-item-active dark:text-[#3d8ef8] dark:nav-active'
+            : [
+                'text-white/45 hover:text-white/90',
+                'dark:text-[#657a9e] dark:hover:text-[#e8f0ff] dark:hover:bg-white/[0.05]',
+              ].join(' ')
+        )
+      }
+      style={({ isActive }) =>
+        isActive
+          ? {
+              background: 'linear-gradient(90deg, rgba(54,96,146,0.35) 0%, rgba(91,155,213,0.12) 100%)',
+              boxShadow: 'inset 0 0 0 1px rgba(91,155,213,0.15)',
+            }
+          : {}
+      }
+    >
+      {({ isActive }) => (
+        <>
+          <span
+            className={cn(
+              'transition-all duration-150 rounded-lg',
+              !isActive && !collapsed && 'dark:bg-white/[0.04] p-1 -m-1'
+            )}
+            style={
+              isActive
+                ? { color: '#5B9BD5', filter: 'drop-shadow(0 0 6px rgba(91,155,213,0.5))' }
+                : {}
+            }
+          >
+            <Icon size={17} strokeWidth={isActive ? 2.2 : 1.8} className="shrink-0" />
+          </span>
+          {!collapsed && <span className="truncate">{t(labelKey)}</span>}
+          {/* Hover glow */}
+          {!isActive && (
+            <span
+              className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+              style={{ background: 'rgba(255,255,255,0.04)' }}
+            />
+          )}
+        </>
+      )}
+    </NavLink>
+  )
+}
+
 export function Sidebar(): JSX.Element {
   const { sidebarOpen, setSidebarOpen, sidebarCollapsed, setSidebarCollapsed } = useUiStore()
   const { user, signOut } = useAuthStore()
@@ -74,7 +142,8 @@ export function Sidebar(): JSX.Element {
         className={cn(
           'fixed top-0 left-0 h-full z-30 flex flex-col transition-all duration-300 ease-in-out',
           sidebarCollapsed ? 'w-[72px]' : 'w-64',
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
+          'dark:backdrop-blur-2xl dark:border-r dark:border-white/[0.06]'
         )}
         style={{
           background: 'linear-gradient(180deg, #0F1923 0%, #121e2d 60%, #0f1923 100%)',
@@ -98,7 +167,7 @@ export function Sidebar(): JSX.Element {
             tabIndex={sidebarCollapsed ? 0 : -1}
           >
             <div
-              className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 shadow-lg"
+              className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 shadow-lg dark:bg-gradient-to-br dark:from-[#3d8ef8] dark:to-[#9768ff]"
               style={{
                 background: 'linear-gradient(135deg, #5B9BD5, #366092)',
                 boxShadow: sidebarCollapsed
@@ -134,10 +203,16 @@ export function Sidebar(): JSX.Element {
               <X size={18} />
             </button>
 
-            {/* Desktop collapse/expand toggle — always visible on desktop */}
+            {/* Desktop collapse/expand toggle */}
             <button
               onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-              className="hidden lg:flex items-center justify-center text-white/30 hover:text-white/80 transition-all duration-150 hover:bg-white/10 rounded-[7px]"
+              className={cn(
+                'hidden lg:flex items-center justify-center text-white/30 rounded-[7px]',
+                'transition-all duration-150',
+                'hover:text-white/80 hover:bg-white/10',
+                'dark:bg-white/[0.05] dark:border dark:border-white/[0.06]',
+                'dark:hover:bg-[#3d8ef8]/20 dark:hover:text-[#3d8ef8]'
+              )}
               style={{ width: 26, height: 26 }}
               aria-label={sidebarCollapsed ? 'Expandir sidebar' : 'Colapsar sidebar'}
               title={sidebarCollapsed ? 'Expandir sidebar' : 'Colapsar sidebar'}
@@ -153,51 +228,14 @@ export function Sidebar(): JSX.Element {
 
         {/* Navigation */}
         <nav className="flex-1 px-2 py-3 overflow-y-auto overflow-x-hidden">
-          {navItems.map(({ to, icon: Icon, labelKey }) => (
-            <NavLink
+          {navItems.map(({ to, icon, labelKey }) => (
+            <NavItem
               key={to}
               to={to}
-              end={to === '/'}
-              title={sidebarCollapsed ? t(labelKey) : undefined}
-              className={({ isActive }) =>
-                cn(
-                  'group relative flex items-center gap-3 rounded-xl mb-0.5 text-sm font-medium transition-all duration-150',
-                  sidebarCollapsed ? 'justify-center w-11 h-11 mx-auto' : 'px-3 py-2.5',
-                  isActive
-                    ? 'text-white sidebar-item-active'
-                    : 'text-white/45 hover:text-white/90'
-                )
-              }
-              style={({ isActive }) =>
-                isActive
-                  ? {
-                      background: 'linear-gradient(90deg, rgba(54,96,146,0.35) 0%, rgba(91,155,213,0.12) 100%)',
-                      boxShadow: 'inset 0 0 0 1px rgba(91,155,213,0.15)',
-                    }
-                  : {}
-              }
-            >
-              {({ isActive }) => (
-                <>
-                  <span
-                    className="transition-all duration-150"
-                    style={isActive ? { color: '#5B9BD5', filter: 'drop-shadow(0 0 6px rgba(91,155,213,0.5))' } : {}}
-                  >
-                    <Icon size={17} strokeWidth={isActive ? 2.2 : 1.8} className="shrink-0" />
-                  </span>
-                  {!sidebarCollapsed && (
-                    <span className="truncate">{t(labelKey)}</span>
-                  )}
-                  {/* Hover glow */}
-                  {!isActive && (
-                    <span
-                      className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-                      style={{ background: 'rgba(255,255,255,0.04)' }}
-                    />
-                  )}
-                </>
-              )}
-            </NavLink>
+              icon={icon}
+              labelKey={labelKey}
+              collapsed={sidebarCollapsed}
+            />
           ))}
         </nav>
 
@@ -216,12 +254,14 @@ export function Sidebar(): JSX.Element {
             <div className="flex items-center gap-3">
               <Avatar name={userName} size="sm" />
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-white/90 truncate">{userName}</p>
-                <p className="text-xs text-white/40 truncate">{user?.email}</p>
+                <p className="text-sm font-medium text-white/90 dark:text-[#e8f0ff]/90 truncate">
+                  {userName}
+                </p>
+                <p className="text-xs text-white/40 dark:text-[#657a9e] truncate">{user?.email}</p>
               </div>
               <button
                 onClick={handleSignOut}
-                className="text-white/30 hover:text-red-400 transition-colors p-1.5 rounded-lg hover:bg-red-500/10"
+                className="text-white/30 hover:text-red-400 dark:hover:text-[#ff4060] transition-colors p-1.5 rounded-lg hover:bg-red-500/10 dark:hover:bg-[#ff4060]/10"
                 title={t('auth.logout')}
                 aria-label={t('auth.logout')}
               >
@@ -233,7 +273,7 @@ export function Sidebar(): JSX.Element {
               <Avatar name={userName} size="sm" />
               <button
                 onClick={handleSignOut}
-                className="text-white/30 hover:text-red-400 transition-colors p-1.5 rounded-lg hover:bg-red-500/10"
+                className="text-white/30 hover:text-red-400 dark:hover:text-[#ff4060] transition-colors p-1.5 rounded-lg hover:bg-red-500/10 dark:hover:bg-[#ff4060]/10"
                 title={t('auth.logout')}
                 aria-label={t('auth.logout')}
               >

--- a/frontend/src/components/shared/StatsBar.tsx
+++ b/frontend/src/components/shared/StatsBar.tsx
@@ -11,33 +11,29 @@ interface StatItemProps {
 
 function StatItem({ label, value, badge, badgeVariant = 'neutral' }: StatItemProps): JSX.Element {
   const badgeClass = {
-    positive: 'text-emerald-400 bg-emerald-400/10',
-    negative: 'text-red-400 bg-red-400/10',
-    warning: 'text-amber-400 bg-amber-400/10',
+    positive: 'text-emerald-400 bg-emerald-400/10 dark:text-[#00dfa2] dark:bg-[#00dfa2]/10',
+    negative: 'text-red-400 bg-red-400/10 dark:text-[#ff4060] dark:bg-[#ff4060]/10',
+    warning: 'text-amber-400 bg-amber-400/10 dark:text-[#ffb340] dark:bg-[#ffb340]/10',
     neutral: 'text-[var(--text-muted)] bg-[var(--surface-raised)]',
   }[badgeVariant]
 
   return (
-    <div className="flex items-center gap-2 px-3 shrink-0">
+    <div className="flex items-center gap-2 px-3 shrink-0 border-r border-[var(--border)] dark:border-white/[0.06] last:border-r-0">
       <div className="flex flex-col">
-        <span className="text-[10px] font-medium text-[var(--text-subtle)] uppercase tracking-wide leading-none mb-0.5">
+        <span className="text-[11px] font-medium text-[var(--text-subtle)] dark:text-[#657a9e] uppercase tracking-wider leading-none mb-0.5">
           {label}
         </span>
-        <span className="text-sm font-bold tabular-nums text-[var(--text-primary)] leading-none">
+        <span className="text-[13px] font-semibold tabular-nums text-[var(--text-primary)] dark:text-[#e8f0ff] leading-none">
           {value}
         </span>
       </div>
       {badge && (
-        <span className={cn('text-[10px] font-semibold px-1.5 py-0.5 rounded-full', badgeClass)}>
+        <span className={cn('text-[10px] px-1.5 py-0.5 rounded-md font-semibold', badgeClass)}>
           {badge}
         </span>
       )}
     </div>
   )
-}
-
-function StatDivider(): JSX.Element {
-  return <div className="w-px h-6 bg-[var(--border)] shrink-0" aria-hidden="true" />
 }
 
 function formatCurrency(amount: number): string {
@@ -69,14 +65,20 @@ export function StatsBar({ onCommandPaletteOpen }: StatsBarProps): JSX.Element {
   const { data, isLoading } = useDashboardV2({ mes: now.getMonth() + 1, year: now.getFullYear() })
   const navigate = useNavigate()
 
+  const barClass = cn(
+    'statsbar-glass hidden md:flex items-center h-11 px-4 sticky top-16 z-40',
+    'border-b border-[var(--border)]',
+    'dark:border-white/[0.06]',
+    'bg-[rgba(255,255,255,0.85)] dark:bg-[rgba(4,8,15,0.85)]'
+  )
+
   if (isLoading || !data) {
     return (
       <div
-        className="statsbar-glass hidden md:flex items-center gap-6 h-11 px-4 sticky top-16 z-40 border-b border-[var(--border)]"
+        className={barClass}
         style={{
-          backdropFilter: 'blur(12px)',
-          WebkitBackdropFilter: 'blur(12px)',
-          background: 'rgba(255,255,255,0.85)',
+          backdropFilter: 'blur(16px)',
+          WebkitBackdropFilter: 'blur(16px)',
         }}
       >
         {[80, 100, 90, 70, 95].map((w, i) => (
@@ -95,11 +97,10 @@ export function StatsBar({ onCommandPaletteOpen }: StatsBarProps): JSX.Element {
 
   return (
     <div
-      className="statsbar-glass hidden md:flex items-center h-11 px-4 sticky top-16 z-40 border-b border-[var(--border)]"
+      className={barClass}
       style={{
-        backdropFilter: 'blur(12px)',
-        WebkitBackdropFilter: 'blur(12px)',
-        background: 'rgba(255,255,255,0.85)',
+        backdropFilter: 'blur(16px)',
+        WebkitBackdropFilter: 'blur(16px)',
       }}
     >
       <div className="flex items-center gap-1 flex-1 overflow-x-auto scrollbar-none">
@@ -109,31 +110,28 @@ export function StatsBar({ onCommandPaletteOpen }: StatsBarProps): JSX.Element {
           badge={formatPct(rf.tasa_ahorro)}
           badgeVariant={rf.tasa_ahorro > 0 ? 'positive' : rf.tasa_ahorro < -5 ? 'negative' : 'warning'}
         />
-        <StatDivider />
         <StatItem
           label="Ingresos"
           value={formatCurrency(rf.ingresos_mes)}
           badge={formatPct(rf.variacion_ingresos_pct)}
           badgeVariant={getBadgeVariant(rf.variacion_ingresos_pct)}
         />
-        <StatDivider />
         <StatItem
           label="Egresos"
           value={formatCurrency(rf.egresos_mes)}
           badge={formatPct(rf.variacion_egresos_pct)}
           badgeVariant={getBadgeVariant(rf.variacion_egresos_pct, true)}
         />
-        <StatDivider />
         <button
           onClick={() => navigate('/prestamos')}
-          className="flex items-center px-3 hover:opacity-80 transition-opacity"
+          className="flex items-center px-3 hover:opacity-80 transition-opacity border-r border-[var(--border)] dark:border-white/[0.06]"
           aria-label="Ver préstamos"
         >
           <div className="flex flex-col">
-            <span className="text-[10px] font-medium text-[var(--text-subtle)] uppercase tracking-wide leading-none mb-0.5">
+            <span className="text-[11px] font-medium text-[var(--text-subtle)] dark:text-[#657a9e] uppercase tracking-wider leading-none mb-0.5">
               Prox. Venc.
             </span>
-            <span className="text-sm font-bold tabular-nums text-[var(--text-primary)] leading-none">
+            <span className="text-[13px] font-semibold tabular-nums text-[var(--text-primary)] dark:text-[#e8f0ff] leading-none">
               {proximoVencimiento}
             </span>
           </div>
@@ -146,13 +144,15 @@ export function StatsBar({ onCommandPaletteOpen }: StatsBarProps): JSX.Element {
         className={cn(
           'ml-4 shrink-0 flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium',
           'text-[var(--text-muted)] bg-[var(--surface-raised)] border border-[var(--border)]',
-          'hover:text-[var(--text-primary)] hover:border-[var(--accent)] transition-all duration-150'
+          'hover:text-[var(--text-primary)] hover:border-[var(--accent)] transition-all duration-150',
+          'dark:text-[#657a9e] dark:bg-white/[0.04] dark:border-white/[0.06]',
+          'dark:hover:text-[#e8f0ff] dark:hover:border-[#3d8ef8]/50'
         )}
         aria-label="Abrir command palette"
         title="Ctrl+K"
       >
         <span>Buscar</span>
-        <kbd className="text-[10px] font-mono bg-[var(--surface)] border border-[var(--border)] px-1 rounded">
+        <kbd className="text-[10px] font-mono bg-[var(--surface)] border border-[var(--border)] dark:bg-white/[0.06] dark:border-white/[0.08] px-1 rounded">
           Ctrl K
         </kbd>
       </button>

--- a/frontend/src/components/shared/__tests__/Layout.test.tsx
+++ b/frontend/src/components/shared/__tests__/Layout.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { Layout } from '@/components/shared/Layout'
+
+// Mock child components to isolate Layout
+vi.mock('@/components/shared/Sidebar', () => ({
+  Sidebar: () => <div data-testid="sidebar" />,
+}))
+vi.mock('@/components/shared/Header', () => ({
+  Header: () => <div data-testid="header" />,
+}))
+vi.mock('@/components/shared/StatsBar', () => ({
+  StatsBar: ({ onCommandPaletteOpen }: { onCommandPaletteOpen: () => void }) => (
+    <div data-testid="stats-bar" onClick={onCommandPaletteOpen} />
+  ),
+}))
+vi.mock('@/components/shared/CommandPalette', () => ({
+  CommandPalette: ({ isOpen }: { isOpen: boolean }) => (
+    <div data-testid="command-palette" data-open={isOpen} />
+  ),
+}))
+vi.mock('@/components/shared/BottomNav', () => ({
+  BottomNav: () => <div data-testid="bottom-nav" />,
+}))
+vi.mock('@/components/onboarding/OnboardingWizard', () => ({
+  OnboardingWizard: ({ onComplete }: { onComplete: () => void }) => (
+    <div data-testid="onboarding-wizard" onClick={onComplete} />
+  ),
+}))
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, Outlet: () => <div data-testid="outlet" /> }
+})
+
+vi.mock('@/store/uiStore', () => ({
+  useUiStore: vi.fn(),
+}))
+vi.mock('@/hooks/useProfile', () => ({
+  useProfile: vi.fn(),
+}))
+
+import { useUiStore } from '@/store/uiStore'
+import { useProfile } from '@/hooks/useProfile'
+
+function setupMocks({
+  sidebarCollapsed = false,
+  profile = null,
+}: {
+  sidebarCollapsed?: boolean
+  profile?: { onboarding_completed?: boolean } | null
+} = {}) {
+  vi.mocked(useUiStore).mockReturnValue({
+    sidebarCollapsed,
+    setSidebarCollapsed: vi.fn(),
+    sidebarOpen: false,
+    setSidebarOpen: vi.fn(),
+  } as ReturnType<typeof useUiStore>)
+
+  vi.mocked(useProfile).mockReturnValue({
+    data: profile,
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useProfile>)
+}
+
+function renderLayout() {
+  return render(
+    <MemoryRouter>
+      <Layout />
+    </MemoryRouter>
+  )
+}
+
+describe('Layout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupMocks()
+  })
+
+  it('renders cursor-glow div in DOM', () => {
+    renderLayout()
+    const cursorGlow = document.getElementById('cursor-glow')
+    expect(cursorGlow).not.toBeNull()
+  })
+
+  it('renders three blob divs for ambient background', () => {
+    const { container } = renderLayout()
+    expect(container.querySelector('.blob-1')).not.toBeNull()
+    expect(container.querySelector('.blob-2')).not.toBeNull()
+    expect(container.querySelector('.blob-3')).not.toBeNull()
+  })
+
+  it('renders blob divs with blob class', () => {
+    const { container } = renderLayout()
+    const blobs = container.querySelectorAll('.blob')
+    expect(blobs.length).toBe(3)
+  })
+
+  it('renders sidebar component', () => {
+    renderLayout()
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+  })
+
+  it('renders header component', () => {
+    renderLayout()
+    expect(screen.getByTestId('header')).toBeInTheDocument()
+  })
+
+  it('renders stats bar component', () => {
+    renderLayout()
+    expect(screen.getByTestId('stats-bar')).toBeInTheDocument()
+  })
+
+  it('renders outlet for page content', () => {
+    renderLayout()
+    expect(screen.getByTestId('outlet')).toBeInTheDocument()
+  })
+
+  it('does not show onboarding when profile is null', () => {
+    setupMocks({ profile: null })
+    renderLayout()
+    expect(screen.queryByTestId('onboarding-wizard')).not.toBeInTheDocument()
+  })
+
+  it('shows onboarding when onboarding_completed is false', () => {
+    setupMocks({ profile: { onboarding_completed: false } })
+    renderLayout()
+    expect(screen.getByTestId('onboarding-wizard')).toBeInTheDocument()
+  })
+
+  it('applies collapsed margin class when sidebarCollapsed is true', () => {
+    setupMocks({ sidebarCollapsed: true })
+    const { container } = renderLayout()
+    const mainArea = container.querySelector('.lg\\:ml-\\[72px\\]')
+    expect(mainArea).not.toBeNull()
+  })
+
+  it('applies expanded margin class when sidebarCollapsed is false', () => {
+    setupMocks({ sidebarCollapsed: false })
+    const { container } = renderLayout()
+    const mainArea = container.querySelector('.lg\\:ml-64')
+    expect(mainArea).not.toBeNull()
+  })
+})

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -16,6 +16,185 @@ const loginSchema = z.object({
 
 type LoginForm = z.infer<typeof loginSchema>
 
+const FEATURES = [
+  { icon: TrendingUp, text: 'Seguimiento de ingresos y egresos en tiempo real' },
+  { icon: Shield, text: 'Tus datos financieros protegidos y privados' },
+  { icon: Zap, text: 'Metas de ahorro y presupuestos inteligentes' },
+] as const
+
+function BrandPanel(): JSX.Element {
+  return (
+    <div className="hidden lg:flex lg:w-1/2 flex-col justify-between p-12 text-white relative overflow-hidden bg-gradient-to-br from-[#020812] via-[#04080f] to-[#080f1e]">
+      {/* Decorative blob inside brand panel */}
+      <div
+        className="absolute -top-32 -left-20 w-96 h-96 rounded-full opacity-20 pointer-events-none"
+        style={{ background: '#3d8ef8', filter: 'blur(100px)' }}
+        aria-hidden="true"
+      />
+      <div
+        className="absolute bottom-0 right-0 w-72 h-72 rounded-full opacity-15 pointer-events-none"
+        style={{ background: '#9768ff', filter: 'blur(80px)' }}
+        aria-hidden="true"
+      />
+
+      {/* Logo */}
+      <div className="flex items-center gap-3 relative z-10">
+        <div className="w-10 h-10 rounded-xl flex items-center justify-center shadow-lg bg-gradient-to-br from-[#3d8ef8] to-[#9768ff]">
+          <span className="font-bold text-white text-lg">Fz</span>
+        </div>
+        <span className="font-bold text-2xl tracking-tight text-[#e8f0ff]">Finza</span>
+      </div>
+
+      {/* Tagline */}
+      <div className="space-y-8 relative z-10">
+        <div>
+          <h2 className="text-4xl font-bold leading-tight mb-4 text-[#e8f0ff]">
+            Gestiona tus finanzas con claridad
+          </h2>
+          <p className="text-[#657a9e] text-lg">
+            Controla ingresos, egresos, metas y mas — todo en un solo lugar.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {FEATURES.map(({ icon: Icon, text }) => (
+            <div key={text} className="flex items-center gap-3">
+              <div className="w-8 h-8 bg-white/[0.06] border border-white/[0.08] rounded-lg flex items-center justify-center shrink-0">
+                <Icon size={16} className="text-[#3d8ef8]" />
+              </div>
+              <span className="text-[#657a9e] text-sm">{text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p className="text-[#657a9e]/60 text-sm italic relative z-10">
+        "Fluye hacia tu libertad financiera"
+      </p>
+    </div>
+  )
+}
+
+function LoginFormCard({
+  onSubmit,
+  serverError,
+  showPassword,
+  onTogglePassword,
+  isSubmitting,
+  register,
+  errors,
+  t,
+}: {
+  onSubmit: (e: React.FormEvent) => void
+  serverError: string | null
+  showPassword: boolean
+  onTogglePassword: () => void
+  isSubmitting: boolean
+  register: ReturnType<typeof useForm<LoginForm>>['register']
+  errors: ReturnType<typeof useForm<LoginForm>>['formState']['errors']
+  t: (key: string) => string
+}): JSX.Element {
+  return (
+    <div className="w-full max-w-md space-y-6">
+      {/* Mobile logo */}
+      <div className="lg:hidden flex items-center gap-2 mb-2">
+        <div className="w-9 h-9 rounded-xl flex items-center justify-center bg-gradient-to-br from-[#3d8ef8] to-[#9768ff]">
+          <span className="font-bold text-white text-sm">Fz</span>
+        </div>
+        <span className="font-bold text-xl text-[var(--text-primary)]">Finza</span>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-[var(--text-primary)] dark:text-[#e8f0ff]">
+          {t('auth.loginTitle')}
+        </h1>
+        <p className="text-sm text-[var(--text-muted)] dark:text-[#657a9e] mt-1">
+          {t('auth.loginSubtitle')}
+        </p>
+      </div>
+
+      {/* Glass card form */}
+      <div className="finza-card dark:card-glass dark:!bg-[rgba(8,15,30,0.7)] dark:!border-white/[0.08] dark:!rounded-2xl dark:!p-10 space-y-4">
+        <form onSubmit={onSubmit} className="space-y-4">
+          {/* Email */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-[var(--text-primary)] dark:text-[#e8f0ff]">
+              {t('auth.email')}
+            </label>
+            <input
+              type="email"
+              placeholder="tu@email.com"
+              className="finza-input w-full dark:bg-white/[0.05] dark:border-white/[0.08] dark:text-[#e8f0ff] dark:placeholder:text-[#657a9e] dark:focus:border-[#3d8ef8]/50 dark:rounded-xl"
+              {...register('email')}
+            />
+            {errors.email && (
+              <p className="text-xs text-alert-red dark:text-[#ff4060]">{errors.email.message}</p>
+            )}
+          </div>
+
+          {/* Password with show/hide */}
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-[var(--text-primary)] dark:text-[#e8f0ff]">
+                {t('auth.password')}
+              </label>
+              <Link
+                to="/forgot-password"
+                className="text-xs text-finza-blue dark:text-[#3d8ef8] hover:underline"
+              >
+                {t('auth.forgotPassword')}
+              </Link>
+            </div>
+            <div className="relative">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                placeholder="..."
+                className="finza-input w-full pr-10 dark:bg-white/[0.05] dark:border-white/[0.08] dark:text-[#e8f0ff] dark:placeholder:text-[#657a9e] dark:focus:border-[#3d8ef8]/50 dark:rounded-xl"
+                {...register('password')}
+              />
+              <button
+                type="button"
+                onClick={onTogglePassword}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)] dark:text-[#657a9e] hover:text-[var(--text-primary)] dark:hover:text-[#e8f0ff]"
+                aria-label={showPassword ? 'Ocultar contrasena' : 'Mostrar contrasena'}
+              >
+                {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+            {errors.password && (
+              <p className="text-xs text-alert-red dark:text-[#ff4060]">{errors.password.message}</p>
+            )}
+          </div>
+
+          {serverError && (
+            <p className="text-sm text-alert-red bg-red-50 dark:bg-[#ff4060]/10 border border-red-200 dark:border-[#ff4060]/20 rounded-lg p-3 dark:text-[#ff4060]">
+              {serverError}
+            </p>
+          )}
+
+          <Button
+            type="submit"
+            isLoading={isSubmitting}
+            className="w-full dark:!bg-gradient-to-r dark:!from-[#3d8ef8] dark:!to-[#9768ff] dark:!rounded-xl dark:!py-3 dark:!font-semibold dark:!text-white dark:!border-0"
+          >
+            {t('auth.login')}
+          </Button>
+        </form>
+
+        <p className="text-center text-sm text-[var(--text-muted)] dark:text-[#657a9e]">
+          {t('auth.noAccount')}{' '}
+          <Link
+            to="/register"
+            className="text-finza-blue dark:text-[#3d8ef8] font-medium hover:underline"
+          >
+            {t('auth.register')}
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}
+
 export function LoginPage(): JSX.Element {
   const navigate = useNavigate()
   const { session, isLoading, setSession } = useAuthStore()
@@ -58,142 +237,21 @@ export function LoginPage(): JSX.Element {
   }
 
   return (
-    <div className="min-h-screen flex">
-      {/* Left brand panel — hidden on mobile */}
-      <div className="hidden lg:flex lg:w-1/2 bg-gradient-to-br from-[#0f2544] via-[#1a3a6b] to-[#2563eb] flex-col justify-between p-12 text-white">
-        {/* Logo */}
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 bg-golden-flow rounded-xl flex items-center justify-center">
-            <span className="font-bold text-[#0f2544] text-lg">F</span>
-          </div>
-          <span className="font-bold text-2xl tracking-tight">Finza</span>
-        </div>
-
-        {/* Tagline */}
-        <div className="space-y-8">
-          <div>
-            <h2 className="text-4xl font-bold leading-tight mb-4">
-              Gestiona tus finanzas con claridad
-            </h2>
-            <p className="text-white/70 text-lg">
-              Controla ingresos, egresos, metas y mas — todo en un solo lugar.
-            </p>
-          </div>
-
-          {/* Feature bullets */}
-          <div className="space-y-4">
-            {[
-              { icon: TrendingUp, text: 'Seguimiento de ingresos y egresos en tiempo real' },
-              { icon: Shield, text: 'Tus datos financieros protegidos y privados' },
-              { icon: Zap, text: 'Metas de ahorro y presupuestos inteligentes' },
-            ].map(({ icon: Icon, text }) => (
-              <div key={text} className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-white/10 rounded-lg flex items-center justify-center shrink-0">
-                  <Icon size={16} className="text-golden-flow" />
-                </div>
-                <span className="text-white/80 text-sm">{text}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Decorative quote */}
-        <p className="text-white/40 text-sm italic">
-          "Fluye hacia tu libertad financiera"
-        </p>
-      </div>
+    <div className="min-h-screen flex bg-[var(--bg)] dark:bg-[#04080f]">
+      <BrandPanel />
 
       {/* Right form panel */}
-      <div className="flex-1 lg:w-1/2 flex items-center justify-center p-8 bg-background">
-        <div className="w-full max-w-md space-y-6">
-          {/* Mobile logo */}
-          <div className="lg:hidden flex items-center gap-2 mb-2">
-            <div className="w-8 h-8 bg-[#0f2544] rounded-lg flex items-center justify-center">
-              <div className="w-5 h-5 bg-golden-flow rounded-md flex items-center justify-center">
-                <span className="font-bold text-[#0f2544] text-xs">F</span>
-              </div>
-            </div>
-            <span className="font-bold text-xl text-[var(--text-primary)]">Finza</span>
-          </div>
-
-          <div>
-            <h1 className="text-2xl font-bold text-[var(--text-primary)]">
-              {t('auth.loginTitle')}
-            </h1>
-            <p className="text-sm text-[var(--text-muted)] mt-1">{t('auth.loginSubtitle')}</p>
-          </div>
-
-          <div className="finza-card space-y-4">
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-              {/* Email */}
-              <div className="space-y-1.5">
-                <label className="text-sm font-medium text-[var(--text-primary)]">
-                  {t('auth.email')}
-                </label>
-                <input
-                  type="email"
-                  placeholder="tu@email.com"
-                  className="finza-input w-full"
-                  {...register('email')}
-                />
-                {errors.email && (
-                  <p className="text-xs text-alert-red">{errors.email.message}</p>
-                )}
-              </div>
-
-              {/* Password with show/hide */}
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <label className="text-sm font-medium text-[var(--text-primary)]">
-                    {t('auth.password')}
-                  </label>
-                  <Link
-                    to="/forgot-password"
-                    className="text-xs text-finza-blue hover:underline"
-                  >
-                    {t('auth.forgotPassword')}
-                  </Link>
-                </div>
-                <div className="relative">
-                  <input
-                    type={showPassword ? 'text' : 'password'}
-                    placeholder="..."
-                    className="finza-input w-full pr-10"
-                    {...register('password')}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword((v) => !v)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-                    aria-label={showPassword ? 'Ocultar contrasena' : 'Mostrar contrasena'}
-                  >
-                    {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                  </button>
-                </div>
-                {errors.password && (
-                  <p className="text-xs text-alert-red">{errors.password.message}</p>
-                )}
-              </div>
-
-              {serverError && (
-                <p className="text-sm text-alert-red bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
-                  {serverError}
-                </p>
-              )}
-
-              <Button type="submit" isLoading={isSubmitting} className="w-full">
-                {t('auth.login')}
-              </Button>
-            </form>
-
-            <p className="text-center text-sm text-[var(--text-muted)]">
-              {t('auth.noAccount')}{' '}
-              <Link to="/register" className="text-finza-blue font-medium hover:underline">
-                {t('auth.register')}
-              </Link>
-            </p>
-          </div>
-        </div>
+      <div className="flex-1 lg:w-1/2 flex items-center justify-center p-8 bg-background dark:bg-[#04080f]">
+        <LoginFormCard
+          onSubmit={handleSubmit(onSubmit)}
+          serverError={serverError}
+          showPassword={showPassword}
+          onTogglePassword={() => setShowPassword((v) => !v)}
+          isSubmitting={isSubmitting}
+          register={register}
+          errors={errors}
+          t={t}
+        />
       </div>
     </div>
   )

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BrowserRouter } from 'react-router-dom'
+import { LoginPage } from '../LoginPage'
+
+// Mock supabase
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: vi.fn(),
+    },
+  },
+}))
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+// Mock auth store
+const mockSetSession = vi.fn()
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: vi.fn(),
+}))
+import { useAuthStore } from '@/store/authStore'
+import { supabase } from '@/lib/supabase'
+
+function setupAuthStore({
+  session = null,
+  isLoading = false,
+}: { session?: unknown; isLoading?: boolean } = {}) {
+  vi.mocked(useAuthStore).mockReturnValue({
+    session,
+    isLoading,
+    setSession: mockSetSession,
+  } as ReturnType<typeof useAuthStore>)
+}
+
+function renderPage() {
+  return render(
+    <BrowserRouter>
+      <LoginPage />
+    </BrowserRouter>
+  )
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupAuthStore()
+  })
+
+  it('renders correctly in default (unauthenticated) state', () => {
+    renderPage()
+    expect(screen.getByText('auth.loginTitle')).toBeInTheDocument()
+  })
+
+  it('renders email and password inputs', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText('tu@email.com')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('...')).toBeInTheDocument()
+  })
+
+  it('renders login submit button', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: /auth\.login/i })).toBeInTheDocument()
+  })
+
+  it('renders brand panel with Finza name on desktop', () => {
+    renderPage()
+    // Brand panel is hidden on mobile via CSS but present in DOM
+    const finzaTexts = screen.getAllByText('Finza')
+    expect(finzaTexts.length).toBeGreaterThan(0)
+  })
+
+  it('shows password when toggle button is clicked', () => {
+    renderPage()
+    const passwordInput = screen.getByPlaceholderText('...')
+    expect(passwordInput).toHaveAttribute('type', 'password')
+
+    const toggleBtn = screen.getByLabelText('Mostrar contrasena')
+    fireEvent.click(toggleBtn)
+
+    expect(passwordInput).toHaveAttribute('type', 'text')
+    expect(screen.getByLabelText('Ocultar contrasena')).toBeInTheDocument()
+  })
+
+  it('shows validation error for invalid email', async () => {
+    renderPage()
+    const submitBtn = screen.getByRole('button', { name: /auth\.login/i })
+    fireEvent.click(submitBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText(/email invalido/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation error for short password', async () => {
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('...'), {
+      target: { value: '123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /auth\.login/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/contrasena/i)).toBeInTheDocument()
+    })
+  })
+
+  it('calls signInWithPassword with correct credentials on submit', async () => {
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue({
+      data: { session: { access_token: 'tok' } },
+      error: null,
+    } as never)
+
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('...'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /auth\.login/i }))
+
+    await waitFor(() => {
+      expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'password123',
+      })
+    })
+  })
+
+  it('shows server error when login fails', async () => {
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Invalid credentials' },
+    } as never)
+
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText('tu@email.com'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('...'), {
+      target: { value: 'wrongpass' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /auth\.login/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('auth.invalidCredentials')).toBeInTheDocument()
+    })
+  })
+
+  it('renders register link', () => {
+    renderPage()
+    expect(screen.getByText('auth.register')).toBeInTheDocument()
+  })
+
+  it('renders forgot password link', () => {
+    renderPage()
+    expect(screen.getByText('auth.forgotPassword')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -34,33 +34,44 @@
     --card-glow-hover: 0 12px 40px rgba(99, 102, 241, 0.18);
   }
   .dark {
-    --bg: #0a0f1e;
-    --surface: #111827;
-    --surface-raised: #1f2937;
-    --surface-overlay: rgba(17,24,39,0.85);
-    --border: #1f2937;
-    --border-strong: #374151;
-    --text-primary: #f9fafb;
-    --text-secondary: #f3f4f6;
-    --text-muted: #9ca3af;
-    --text-subtle: #6b7280;
-    --sidebar: #07090f;
-    --sidebar-fg: rgba(255,255,255,0.90);
-    --sidebar-muted: rgba(255,255,255,0.45);
-    --accent: #818cf8;
-    --accent-hover: #6366f1;
-    --accent-muted: rgba(129,140,248,0.15);
-    --success: #34d399;
-    --success-muted: rgba(52,211,153,0.15);
-    --danger: #f87171;
-    --danger-muted: rgba(248,113,113,0.15);
-    --warning: #fbbf24;
-    --warning-muted: rgba(251,191,36,0.15);
-    --shadow-sm: 0 1px 3px rgba(0,0,0,0.3);
-    --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4);
-    --shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.5);
-    --card-glow: 0 8px 32px rgba(129, 140, 248, 0.08);
-    --card-glow-hover: 0 12px 40px rgba(129, 140, 248, 0.20);
+    /* Premium dark palette — mockup tokens */
+    --bg: #04080f;
+    --surface: #080f1e;
+    --surface-raised: #0d1829;
+    --surface-overlay: rgba(8,15,30,0.85);
+    --border: #1f2e45;
+    --border-strong: #1f2e45;
+    --text-primary: #e8f0ff;
+    --text-secondary: #c8d8f0;
+    --text-muted: #657a9e;
+    --text-subtle: #4a5e7a;
+    --sidebar: #080f1e;
+    --sidebar-fg: rgba(232,240,255,0.95);
+    --sidebar-muted: rgba(101,122,158,0.7);
+    --accent: #3d8ef8;
+    --accent-hover: #2a7be8;
+    --accent-muted: rgba(61,142,248,0.15);
+    --success: #00dfa2;
+    --success-muted: rgba(0,223,162,0.15);
+    --danger: #ff4060;
+    --danger-muted: rgba(255,64,96,0.15);
+    --warning: #ffb340;
+    --warning-muted: rgba(255,179,64,0.15);
+    --shadow-sm: 0 1px 3px rgba(0,0,0,0.5);
+    --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.6);
+    --shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.7);
+    --card-glow: 0 8px 32px rgba(61,142,248,0.08);
+    --card-glow-hover: 0 12px 40px rgba(61,142,248,0.18);
+    /* Finza premium tokens */
+    --finza-blue: #3d8ef8;
+    --finza-green: #00dfa2;
+    --finza-red: #ff4060;
+    --finza-yellow: #ffb340;
+    --finza-purple: #9768ff;
+    --finza-cyan: #00dfff;
+    --finza-t2: #657a9e;
+    --finza-border: rgba(255,255,255,0.06);
+    --finza-glass: rgba(8,15,30,0.6);
   }
   * { @apply border-border; }
   body {
@@ -158,7 +169,7 @@
 }
 
 /* ========== Cursor glow — dark only ========== */
-.dark #cursor-glow {
+html.dark #cursor-glow {
   position: fixed;
   inset: 0;
   pointer-events: none;
@@ -171,17 +182,18 @@
 }
 
 /* ========== Ambient blobs — dark only ========== */
-.blob {
+html.dark .blob {
   position: fixed;
   border-radius: 50%;
   filter: blur(120px);
   pointer-events: none;
-  opacity: 0.18;
+  z-index: 0;
+  opacity: 0.15;
   animation: blobdrift 18s ease-in-out infinite alternate;
 }
-.blob-1 { width: 500px; height: 500px; background: #3d8ef8; top: -200px; left: -100px; animation-delay: 0s; }
-.blob-2 { width: 400px; height: 400px; background: #9768ff; top: 40%; right: -150px; animation-delay: -6s; }
-.blob-3 { width: 350px; height: 350px; background: #00dfff; bottom: -100px; left: 30%; animation-delay: -12s; }
+html.dark .blob-1 { width: 500px; height: 500px; background: #3d8ef8; top: -200px; left: -100px; animation-delay: 0s; }
+html.dark .blob-2 { width: 400px; height: 400px; background: #9768ff; top: 40%; right: -150px; animation-delay: -6s; }
+html.dark .blob-3 { width: 350px; height: 350px; background: #00dfff; bottom: -100px; left: 30%; animation-delay: -12s; }
 
 @keyframes blobdrift {
   0%   { transform: translate(0, 0) scale(1); }
@@ -189,26 +201,26 @@
 }
 
 /* ========== Dot grid — dark only ========== */
-.dark body::before {
+html.dark body::before {
   content: '';
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 1;
-  background-image: radial-gradient(circle, rgba(255,255,255,0.13) 1px, transparent 1px);
+  z-index: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.10) 1px, transparent 1px);
   background-size: 28px 28px;
   mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
   -webkit-mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
 }
 
 /* ========== Film grain — dark only ========== */
-.dark body::after {
+html.dark body::after {
   content: '';
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 2;
-  opacity: 0.035;
+  z-index: 1;
+  opacity: 0.03;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
@@ -348,5 +360,60 @@
     width: 3px;
     background: linear-gradient(180deg, #5B9BD5, #366092);
     border-radius: 0 3px 3px 0;
+  }
+  .dark .sidebar-item-active::before {
+    background: linear-gradient(180deg, #3d8ef8, #9768ff);
+  }
+
+  /* ===== Card glassmorphism — premium ===== */
+  .card-glass {
+    background: rgba(8,15,30,0.6);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 14px;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .card-glass:hover {
+    border-color: rgba(255,255,255,0.10);
+    box-shadow: 0 4px 30px rgba(0,0,0,0.3);
+  }
+
+  /* ===== KPI typography — premium ===== */
+  .kpi-value {
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .kpi-label {
+    font-size: 11px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--finza-t2, #657a9e);
+  }
+
+  /* ===== Page title — premium ===== */
+  .page-title-premium {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+  }
+
+  /* ===== Nav active — premium ===== */
+  .nav-active {
+    background: rgba(61,142,248,0.12) !important;
+    color: #3d8ef8 !important;
+  }
+
+  /* ===== Prediction card variants ===== */
+  .pred-card-positive {
+    border-color: rgba(0,223,162,0.3) !important;
+  }
+  .pred-card-negative {
+    border-color: rgba(255,64,96,0.3) !important;
+    background: rgba(255,64,96,0.04) !important;
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,12 +5,22 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Brand (backward-compat)
-        'finza-blue': { DEFAULT: '#2563eb', light: '#60a5fa', dark: '#1d4ed8' },
+        // Brand legacy (backward-compat)
         'prosperity-green': '#10b981',
         'golden-flow': '#f59e0b',
         'alert-red': '#ef4444',
         'flow-light': '#eff6ff',
+        // Premium design system tokens
+        'finza-blue': '#3d8ef8',
+        'finza-green': '#00dfa2',
+        'finza-red': '#ff4060',
+        'finza-yellow': '#ffb340',
+        'finza-purple': '#9768ff',
+        'finza-cyan': '#00dfff',
+        'finza-t2': '#657a9e',
+        'finza-bg': '#04080f',
+        'finza-bg2': '#080f1e',
+        'finza-bg3': '#0d1829',
         // Semanticos via CSS vars
         background: 'var(--bg)',
         surface: 'var(--surface)',


### PR DESCRIPTION
Closes #113

## Changes

- **globals.css**: Dark palette actualizado a tokens exactos del mockup (#04080f / #080f1e / #0d1829). CSS custom properties `--finza-*` para blue, green, red, yellow, purple, cyan, t2, border, glass. Utility classes: `card-glass`, `kpi-value`, `kpi-label`, `page-title-premium`, `nav-active`, `pred-card-positive/negative`. Efectos de fondo (`html.dark body::before/after`, blob, cursor-glow) restringidos a `html.dark`
- **tailwind.config.js**: Agrega colores `finza-blue`, `finza-green`, `finza-red`, `finza-yellow`, `finza-purple`, `finza-cyan`, `finza-t2`, `finza-bg`, `finza-bg2`, `finza-bg3` como valores flat (no objetos)
- **LoginPage.tsx**: Extraidos `BrandPanel` y `LoginFormCard` como sub-componentes. Dark mode: `bg-[#04080f]`, card glass `rgba(8,15,30,0.7)` backdrop-blur-xl, logo "Fz" con gradient blue→purple, inputs `bg-white/[0.05]` con focus border finza-blue, botón CTA gradient from-finza-blue to-finza-purple. Light mode sin cambios funcionales
- **Sidebar.tsx**: Extraido `NavItem` como sub-componente. Dark: `backdrop-blur-2xl border-white/[0.06]`, toggle button `dark:bg-white/[0.05] dark:hover:bg-[#3d8ef8]/20`, logo icon `dark:bg-gradient-to-br dark:from-[#3d8ef8] dark:to-[#9768ff]`, nav items `dark:text-[#657a9e]` con active `dark:text-[#3d8ef8]`, logout `dark:hover:text-[#ff4060]`
- **StatsBar.tsx**: Background `dark:bg-[rgba(4,8,15,0.85)]` con `backdrop-blur: 16px`, stat labels `dark:text-[#657a9e]`, values `dark:text-[#e8f0ff]`, badges con variantes finza-green/red/yellow, divisores `dark:border-white/[0.06]`

## Tests

- `LoginPage.test.tsx`: 11 tests — render, inputs, validaciones, submit flow, server error, toggle password, links
- `Layout.test.tsx`: 11 tests — cursor-glow div, blob-1/2/3 presence, sidebar/header/stats render, onboarding logic, margin clases collapsed/expanded
- Regresion `Sidebar.test.tsx`: 13 passing (sin cambios requeridos)
- Regresion `StatsBar.test.tsx`: 8 passing (sin cambios requeridos)
- Total nuevos/modificados: 43 passing

## Screenshots

No disponibles en entorno headless. Los efectos de glassmorphism, blobs y cursor glow requieren dark mode activo en browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)