### PR TITLE
feat(ui): align visual design with mockup

### DIFF
--- a/frontend/src/pages/TarjetasPage.tsx
+++ b/frontend/src/pages/TarjetasPage.tsx
@@ -64,14 +64,17 @@ type TarjetaFormData = z.infer<typeof TarjetaSchema>
 
 // ─── Card visual component ─────────────────────────────────────────────────────
 
-function getCardGradient(red: Tarjeta['red'], color: string | null): string {
+function getCardGradient(red: Tarjeta['red'], tipo: Tarjeta['tipo'], color: string | null): string {
   if (color) return `linear-gradient(135deg, ${color}dd, ${color}88)`
+  if (tipo === 'debito') {
+    return 'linear-gradient(135deg, #0e5239 0%, #072b1f 50%, #041610 100%)'
+  }
   const gradients: Record<Tarjeta['red'], string> = {
-    visa: 'linear-gradient(135deg, #1a1f71, #2563eb)',
-    mastercard: 'linear-gradient(135deg, #eb4d1c, #f59e0b)',
-    amex: 'linear-gradient(135deg, #0a6640, #16a34a)',
-    discover: 'linear-gradient(135deg, #ea580c, #f97316)',
-    otro: 'linear-gradient(135deg, #6d28d9, #a78bfa)',
+    visa: 'linear-gradient(135deg, #1a3a6b 0%, #0d1e40 50%, #0a1628 100%)',
+    mastercard: 'linear-gradient(135deg, #3d1278 0%, #1e0a40 50%, #0f0620 100%)',
+    amex: 'linear-gradient(135deg, #0e5239 0%, #072b1f 50%, #041610 100%)',
+    discover: 'linear-gradient(135deg, #4a1a00 0%, #2a0e00 50%, #160700 100%)',
+    otro: 'linear-gradient(135deg, #3d1278 0%, #1e0a40 50%, #0f0620 100%)',
   }
   return gradients[red]
 }
@@ -93,17 +96,33 @@ function CardVisual({ tarjeta, onClick }: CardVisualProps): JSX.Element {
       type="button"
       onClick={onClick}
       className={cn(
-        'relative w-full rounded-2xl p-5 text-white overflow-hidden',
-        'transition-transform duration-200 ease-out',
-        'hover:-translate-y-1 hover:scale-[1.01]',
+        'relative w-full text-white overflow-hidden',
+        'transition-all duration-250 ease-out',
+        'hover:-translate-y-1 hover:scale-[1.01] hover:shadow-[0_20px_60px_rgba(0,0,0,0.5)]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50',
         !tarjeta.activa && 'opacity-60'
       )}
-      style={{ background: getCardGradient(tarjeta.red, tarjeta.color), minHeight: 180 }}
+      style={{
+        background: getCardGradient(tarjeta.red, tarjeta.tipo, tarjeta.color),
+        minHeight: 180,
+        borderRadius: '22px',
+        padding: '28px',
+        border: '1px solid rgba(255,255,255,0.1)',
+      }}
       aria-label={`Tarjeta ${tarjeta.banco}`}
     >
+      {/* Glare overlay (replicates ::before from mockup) */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background: 'radial-gradient(ellipse 70% 60% at 20% 30%, rgba(255,255,255,0.14), transparent 60%)',
+          borderRadius: '22px',
+        }}
+        aria-hidden="true"
+      />
+
       {/* Chip SVG */}
-      <div className="absolute top-5 left-5">
+      <div className="absolute top-7 left-7">
         <svg width="40" height="30" viewBox="0 0 40 30" aria-hidden="true">
           <rect x="2" y="2" width="36" height="26" rx="4" fill="#d4a017" stroke="#b8860b" strokeWidth="0.5" />
           <rect x="2" y="11" width="36" height="8" fill="#b8860b" opacity="0.7" />
@@ -113,26 +132,64 @@ function CardVisual({ tarjeta, onClick }: CardVisualProps): JSX.Element {
         </svg>
       </div>
 
-      {/* Bank name */}
-      <div className="absolute top-5 right-5 text-right">
-        <p className="text-xs font-semibold tracking-wide text-white/80 uppercase">{tarjeta.banco}</p>
+      {/* Bank name + tipo badge */}
+      <div className="absolute top-7 right-7 text-right">
+        <p
+          className="font-semibold tracking-widest uppercase"
+          style={{ fontSize: '10px', opacity: 0.55 }}
+        >
+          {tarjeta.banco}
+        </p>
         {!tarjeta.activa && (
           <span className="text-xs bg-white/20 rounded px-1.5 py-0.5 mt-1 inline-block">Inactiva</span>
         )}
       </div>
 
       {/* Card number */}
-      <div className="absolute bottom-14 left-5 text-base font-mono tracking-widest text-white/90">
+      <div
+        className="absolute font-mono text-white/90"
+        style={{
+          bottom: '56px',
+          left: '28px',
+          fontSize: '16px',
+          fontWeight: 600,
+          letterSpacing: '0.2em',
+        }}
+      >
         •••• •••• •••• {tarjeta.ultimos_digitos}
       </div>
 
       {/* Footer */}
-      <div className="absolute bottom-5 left-5 right-5 flex items-end justify-between">
+      <div
+        className="absolute flex items-end justify-between"
+        style={{ bottom: '28px', left: '28px', right: '28px' }}
+      >
         <div>
-          <p className="text-xs text-white/60 uppercase tracking-wider">Saldo</p>
-          <p className="text-lg font-bold text-white">{formattedBalance}</p>
+          <p
+            className="uppercase text-white/50"
+            style={{ fontSize: '10px', letterSpacing: '0.08em', marginBottom: '2px' }}
+          >
+            Saldo
+          </p>
+          <p
+            className="text-white font-bold tabular-nums"
+            style={{ fontSize: '26px', letterSpacing: '-0.03em' }}
+          >
+            {formattedBalance}
+          </p>
         </div>
-        <p className="text-sm font-bold text-white/80 uppercase tracking-widest">{tarjeta.red}</p>
+        <span
+          className="font-semibold"
+          style={{
+            fontSize: '10px',
+            padding: '4px 10px',
+            borderRadius: '20px',
+            background: tarjeta.tipo === 'debito' ? 'rgba(0,223,162,0.2)' : 'rgba(61,142,248,0.2)',
+            color: tarjeta.tipo === 'debito' ? 'rgba(150,255,220,0.9)' : 'rgba(200,220,255,0.9)',
+          }}
+        >
+          {tarjeta.tipo === 'credito' ? 'Crédito' : 'Débito'}
+        </span>
       </div>
     </button>
   )

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -39,8 +39,8 @@
     --surface: #080f1e;
     --surface-raised: #0d1829;
     --surface-overlay: rgba(8,15,30,0.85);
-    --border: #1f2e45;
-    --border-strong: #1f2e45;
+    --border: rgba(255,255,255,0.06);
+    --border-strong: rgba(255,255,255,0.10);
     --text-primary: #e8f0ff;
     --text-secondary: #c8d8f0;
     --text-muted: #657a9e;
@@ -188,7 +188,7 @@ html.dark .blob {
   filter: blur(120px);
   pointer-events: none;
   z-index: 0;
-  opacity: 0.15;
+  opacity: 0.18;
   animation: blobdrift 18s ease-in-out infinite alternate;
 }
 html.dark .blob-1 { width: 500px; height: 500px; background: #3d8ef8; top: -200px; left: -100px; animation-delay: 0s; }
@@ -206,8 +206,8 @@ html.dark body::before {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 0;
-  background-image: radial-gradient(circle, rgba(255,255,255,0.10) 1px, transparent 1px);
+  z-index: 1;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.13) 1px, transparent 1px);
   background-size: 28px 28px;
   mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
   -webkit-mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
@@ -379,11 +379,11 @@ html.dark body::after {
     box-shadow: 0 4px 30px rgba(0,0,0,0.3);
   }
   .dark .card-glass {
-    background: rgba(255, 255, 255, 0.03);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    background: rgba(8, 15, 30, 0.6);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
     border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 12px;
+    border-radius: 14px;
   }
 
   /* ===== KPI typography — premium ===== */


### PR DESCRIPTION
## Cambios

- **Blob opacity**: 0.15 → 0.18 para coincidir con spec del mockup
- **Dot grid**: opacidad de puntos 0.10 → 0.13, z-index corregido a 1
- **Dark border token**: `--border` cambiado de `#1f2e45` (opaco) a `rgba(255,255,255,0.06)` (translucido como el mockup) — afecta todos los bordes de cards en dark mode
- **card-glass dark override**: fix del background override que usaba `rgba(255,255,255,0.03)` en lugar del glassmorphism correcto `rgba(8,15,30,0.6)`
- **TarjetasPage wallet cards**:
  - border-radius actualizado a 22px (antes rounded-2xl ~16px)
  - padding actualizado a 28px (antes p-5 = 20px)
  - Gradientes actualizados a la paleta del mockup (azul oscuro para visa/crédito, verde oscuro para débito, morado para mastercard)
  - Glare overlay (radial-gradient) agregado para replicar el efecto `::before` del mockup
  - Footer rediseñado: saldo en 26px tabular, badge Crédito/Débito con colores correctos
  - `getCardGradient` recibe `tipo` para aplicar gradiente verde a tarjetas de débito

## Test plan
- [x] vitest --run: 464 tests passing (0 regresiones)
- [ ] Comparacion visual con mockup en http://localhost
- [ ] Verificar dark mode activo (default)
- [ ] Verificar blobs y dot grid visibles en el fondo
- [ ] Verificar bordes de cards translucidos (no opacos)
- [ ] Verificar TarjetasPage con tarjetas de credito y debito

🤖 Generated with Claude Code