### PR TITLE
feat(ui): mockup parity v4 — hero card, dots, toggles, stats bar

### DIFF
--- a/frontend/src/features/metas/components/MetasResumenCards.tsx
+++ b/frontend/src/features/metas/components/MetasResumenCards.tsx
@@ -44,7 +44,7 @@ export function MetasResumenCards(): JSX.Element {
       )}
 
       {/* Total ahorrado */}
-      <div className="finza-card border-l-4 border-prosperity-green">
+      <div className="finza-card border border-[rgba(255,255,255,0.06)]">
         <p className="text-sm font-medium text-[var(--text-muted)] mb-1">
           Total ahorrado
         </p>
@@ -58,7 +58,7 @@ export function MetasResumenCards(): JSX.Element {
       </div>
 
       {/* Metas activas */}
-      <div className="finza-card border-l-4 border-finza-blue">
+      <div className="finza-card border border-[rgba(255,255,255,0.06)]">
         <p className="text-sm font-medium text-[var(--text-muted)] mb-1">Metas activas</p>
         <p
           className="text-2xl font-bold text-finza-blue"
@@ -73,7 +73,7 @@ export function MetasResumenCards(): JSX.Element {
       </div>
 
       {/* Cumplimiento promedio */}
-      <div className="finza-card border-l-4 border-golden-flow">
+      <div className="finza-card border border-[rgba(255,255,255,0.06)]">
         <p className="text-sm font-medium text-[var(--text-muted)] mb-1">
           Cumplimiento promedio
         </p>

--- a/frontend/src/features/presupuestos/components/BudgetProgressBar.tsx
+++ b/frontend/src/features/presupuestos/components/BudgetProgressBar.tsx
@@ -20,9 +20,9 @@ export function BudgetProgressBar({
   const pct = Math.min(100, Math.max(0, porcentaje))
 
   return (
-    <div className="w-full bg-white/[0.06] dark:bg-white/[0.06] rounded-full h-2 overflow-hidden">
+    <div className="w-full bg-white/[0.06] dark:bg-white/[0.06] rounded-full h-[6px] overflow-hidden">
       <div
-        className="h-2 rounded-full transition-all duration-300"
+        className="h-[6px] rounded-full transition-all duration-300"
         style={{ width: `${pct}%`, background: getBudgetGradient(porcentaje) }}
         role="progressbar"
         aria-valuenow={Math.round(porcentaje)}

--- a/frontend/src/pages/ConfiguracionPage.tsx
+++ b/frontend/src/pages/ConfiguracionPage.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { toast } from 'sonner'
-import { Sun, Moon, Camera, DollarSign, Clock, Tag, Trash2, Plus } from 'lucide-react'
+import { Camera, DollarSign, Clock, Tag, Trash2, Plus } from 'lucide-react'
 import * as Icons from 'lucide-react'
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -461,55 +461,56 @@ export function ConfiguracionPage(): JSX.Element {
 
       {/* Tab: Appearance */}
       {activeTab === 'appearance' && (
-        <div className="card-glass p-6 space-y-4">
-          <p className="text-sm text-[var(--text-muted)]">{t('settings.currentTheme')}</p>
-          <div className="grid grid-cols-2 gap-4">
-            {/* Light mode card */}
+        <div
+          className="rounded-[20px] border border-[rgba(255,255,255,0.06)] bg-[rgba(8,15,30,0.6)] overflow-hidden"
+        >
+          {/* Row: Modo oscuro */}
+          <div className="flex items-center justify-between px-5 py-4 border-b border-[rgba(255,255,255,0.06)]">
+            <div>
+              <h4 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                {t('settings.darkMode')}
+              </h4>
+              <p className="text-[12px] text-[#657a9e]">{t('settings.currentTheme')}</p>
+            </div>
             <button
-              onClick={() => setTheme('light')}
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
               className={cn(
-                'p-4 rounded-xl border-2 transition-all duration-200 text-left space-y-2',
-                theme === 'light'
-                  ? 'border-finza-blue bg-finza-blue/5'
-                  : 'border-border hover:border-finza-blue/40'
+                'relative w-[42px] h-6 rounded-full transition-colors duration-200 flex-shrink-0',
+                theme === 'dark' ? 'bg-[#3d8ef8]' : 'bg-[#1f2e45]'
               )}
+              aria-label="Toggle modo oscuro"
             >
-              <div className="w-full h-16 bg-[#f0f4f8] rounded-lg flex items-center justify-center border border-[#e2e8f0]">
-                <div className="w-8 h-8 bg-white rounded-md shadow-sm" />
-              </div>
-              <div className="flex items-center gap-2">
-                <Sun size={14} className="text-golden-flow" />
-                <span className="text-sm font-medium text-[var(--text-primary)]">
-                  {t('settings.lightMode')}
-                </span>
-              </div>
-              {theme === 'light' && (
-                <div className="w-2 h-2 rounded-full bg-finza-blue ml-auto" />
-              )}
+              <span
+                className={cn(
+                  'absolute top-[3px] w-[18px] h-[18px] rounded-full bg-white shadow-sm transition-all duration-200',
+                  theme === 'dark' ? 'left-[21px]' : 'left-[3px]'
+                )}
+              />
             </button>
+          </div>
 
-            {/* Dark mode card */}
+          {/* Row: Modo claro */}
+          <div className="flex items-center justify-between px-5 py-4">
+            <div>
+              <h4 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                {t('settings.lightMode')}
+              </h4>
+              <p className="text-[12px] text-[#657a9e]">Interfaz con fondo claro</p>
+            </div>
             <button
-              onClick={() => setTheme('dark')}
+              onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
               className={cn(
-                'p-4 rounded-xl border-2 transition-all duration-200 text-left space-y-2',
-                theme === 'dark'
-                  ? 'border-finza-blue bg-finza-blue/5'
-                  : 'border-border hover:border-finza-blue/40'
+                'relative w-[42px] h-6 rounded-full transition-colors duration-200 flex-shrink-0',
+                theme === 'light' ? 'bg-[#3d8ef8]' : 'bg-[#1f2e45]'
               )}
+              aria-label="Toggle modo claro"
             >
-              <div className="w-full h-16 bg-[#0f172a] rounded-lg flex items-center justify-center border border-[#334155]">
-                <div className="w-8 h-8 bg-[#1e293b] rounded-md shadow-sm" />
-              </div>
-              <div className="flex items-center gap-2">
-                <Moon size={14} className="text-finza-blue-light" />
-                <span className="text-sm font-medium text-[var(--text-primary)]">
-                  {t('settings.darkMode')}
-                </span>
-              </div>
-              {theme === 'dark' && (
-                <div className="w-2 h-2 rounded-full bg-finza-blue ml-auto" />
-              )}
+              <span
+                className={cn(
+                  'absolute top-[3px] w-[18px] h-[18px] rounded-full bg-white shadow-sm transition-all duration-200',
+                  theme === 'light' ? 'left-[21px]' : 'left-[3px]'
+                )}
+              />
             </button>
           </div>
         </div>

--- a/frontend/src/pages/FondoEmergenciaPage.tsx
+++ b/frontend/src/pages/FondoEmergenciaPage.tsx
@@ -15,45 +15,6 @@ import {
 
 type ModalMode = 'crear' | 'depositar' | 'retirar' | null
 
-function ProgressBar({ porcentaje }: { porcentaje: number }) {
-  const color =
-    porcentaje >= 100
-      ? 'var(--success)'
-      : porcentaje >= 33
-      ? '#FFC000'
-      : 'var(--danger)'
-
-  const hitos = [
-    { pct: 33.3, label: '1 mes' },
-    { pct: 100, label: '3 meses' },
-    { pct: 200, label: '6 meses' },
-  ]
-
-  const barPct = Math.min(porcentaje, 100)
-
-  return (
-    <div className="mb-6">
-      <div className="relative h-4 bg-surface-raised rounded-full overflow-visible mb-6">
-        <div
-          className="h-4 rounded-full transition-all duration-500"
-          style={{ width: `${barPct}%`, backgroundColor: color }}
-        />
-        {hitos.map((h) => (
-          <div
-            key={h.pct}
-            className="absolute top-0 h-4 w-0.5 bg-[var(--border)] z-10"
-            style={{ left: `${Math.min(h.pct, 100)}%` }}
-          >
-            <span className="absolute top-6 left-1/2 -translate-x-1/2 text-[10px] text-[var(--text-muted)] whitespace-nowrap">
-              {h.label}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
 export function FondoEmergenciaPage(): JSX.Element {
   const { t } = useTranslation()
   const { data: fondo, isLoading } = useFondoEmergencia()
@@ -144,37 +105,71 @@ export function FondoEmergenciaPage(): JSX.Element {
         </div>
       ) : (
         <>
-          {/* KPI Cards */}
-          <div className="grid grid-cols-2 gap-3 mb-6">
-            <div className="card-glass p-5 dark:border-finza-cyan/20">
-              <p className="kpi-label dark:text-finza-t2">{t('fondoEmergencia.montoActual')}</p>
-              <p className="kpi-value dark:text-finza-cyan mt-2 money">{formatCurrency(fondo.monto_actual)}</p>
+          {/* Hero Card */}
+          <div
+            className="relative rounded-[20px] p-8 overflow-hidden mb-4"
+            style={{
+              background: 'linear-gradient(135deg, rgba(0,223,162,0.1), rgba(61,142,248,0.05))',
+              border: '1px solid rgba(0,223,162,0.2)',
+            }}
+          >
+            {/* Decorative blob */}
+            <div
+              className="absolute -top-10 -right-10 w-48 h-48 rounded-full pointer-events-none"
+              style={{ background: 'radial-gradient(circle, rgba(0,223,162,0.15), transparent 70%)' }}
+            />
+
+            {/* Label */}
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-[#00dfa2] mb-1">
+              {t('fondoEmergencia.montoActual')}
+            </p>
+
+            {/* Monto */}
+            <p className="text-[42px] font-extrabold tabular-nums text-[var(--text-primary)] leading-none mb-2">
+              {formatCurrency(fondo.monto_actual)}
+            </p>
+
+            {/* Subtitle */}
+            <p className="text-sm text-[#657a9e] mb-5">
+              Cobertura para ~{fondo.meta_meses} {fondo.meta_meses === 1 ? 'mes' : 'meses'} de gastos
+            </p>
+
+            {/* Progress bar */}
+            <div className="h-2 rounded-full bg-white/10 overflow-hidden mb-2">
+              <div
+                className="h-2 rounded-full transition-all duration-500"
+                style={{
+                  width: `${Math.min(fondo.porcentaje, 100)}%`,
+                  background: 'linear-gradient(90deg, #00dfa2, #00dfff)',
+                }}
+              />
             </div>
-            <div className="card-glass p-5 dark:border-finza-cyan/20">
-              <p className="kpi-label dark:text-finza-t2">{t('fondoEmergencia.metaCalculada')}</p>
-              <p className="kpi-value dark:text-[#e8f0ff] mt-2 money">
-                {fondo.meta_calculada ? formatCurrency(fondo.meta_calculada) : '—'}
-              </p>
+
+            {/* Meta row */}
+            <div className="flex justify-between text-xs text-[#657a9e]">
+              <span>{fondo.porcentaje.toFixed(1)}% de la meta</span>
+              {fondo.meta_calculada && fondo.meta_calculada > fondo.monto_actual && (
+                <span>Faltan {formatCurrency(fondo.meta_calculada - fondo.monto_actual)}</span>
+              )}
             </div>
-            <div className="card-glass p-5">
-              <p className="kpi-label dark:text-finza-t2">{t('fondoEmergencia.porcentaje')}</p>
-              <p className={cn('kpi-value mt-2', fondo.porcentaje >= 100 ? 'text-[var(--success)] dark:text-finza-green' : 'dark:text-finza-cyan')}>
-                {fondo.porcentaje.toFixed(1)}%
-              </p>
-            </div>
+          </div>
+
+          {/* Info cards 2 col */}
+          <div className="grid grid-cols-2 gap-3 mb-4">
             <div className="card-glass p-5">
               <p className="kpi-label dark:text-finza-t2">{t('fondoEmergencia.sugerenciaMensual')}</p>
-              <p className="kpi-value dark:text-finza-yellow mt-2 money">
+              <p className="text-xl font-bold tabular-nums mt-2" style={{ color: '#ffb340' }}>
                 {fondo.meta_calculada
                   ? formatCurrency(Math.max(0, (fondo.meta_calculada - fondo.monto_actual) / 12))
                   : '—'}
               </p>
             </div>
-          </div>
-
-          {/* Progress bar */}
-          <div className="card-glass p-5 mb-4 dark:border-finza-cyan/20">
-            <ProgressBar porcentaje={fondo.porcentaje} />
+            <div className="card-glass p-5">
+              <p className="kpi-label dark:text-finza-t2">{t('fondoEmergencia.metaCalculada')}</p>
+              <p className="text-xl font-bold tabular-nums mt-2" style={{ color: '#3d8ef8' }}>
+                {fondo.meta_calculada ? formatCurrency(fondo.meta_calculada) : '—'}
+              </p>
+            </div>
           </div>
 
           {/* Meta selector */}
@@ -202,14 +197,15 @@ export function FondoEmergenciaPage(): JSX.Element {
           <div className="flex gap-3">
             <button
               onClick={() => setModal('depositar')}
-              className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl bg-[var(--success)] text-white font-medium text-sm"
+              className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl font-medium text-sm text-white"
+              style={{ background: 'linear-gradient(135deg, #00dfa2, #00b87a)' }}
             >
               <ArrowUpCircle size={16} />
               {t('fondoEmergencia.depositar')}
             </button>
             <button
               onClick={() => setModal('retirar')}
-              className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl bg-surface-raised text-[var(--text-primary)] font-medium text-sm border border-[var(--border)]"
+              className="flex-1 flex items-center justify-center gap-2 py-2.5 rounded-xl bg-transparent text-[var(--text-primary)] font-medium text-sm border border-[var(--border)]"
             >
               <ArrowDownCircle size={16} />
               {t('fondoEmergencia.retirar')}

--- a/frontend/src/pages/NotificacionesPage.tsx
+++ b/frontend/src/pages/NotificacionesPage.tsx
@@ -14,38 +14,47 @@ import { toast } from 'sonner'
 import { useEffect } from 'react'
 import { getApiErrorMessage } from '@/lib/apiError'
 
-const TIPO_CONFIG: Record<
+const DOT_COLOR: Record<string, string> = {
+  urgente: '#ff4060',
+  logro: '#00dfa2',
+  informativa: '#3d8ef8',
+  advertencia: '#ffb340',
+}
+
+const SECTION_CONFIG: Record<
   string,
-  { color: string; bgColor: string; darkColorClass: string; icon: typeof AlertTriangle; label: string }
+  { icon: typeof AlertTriangle; label: string; textColor: string }
 > = {
   urgente: {
-    color: 'var(--danger)',
-    bgColor: 'var(--danger)',
-    darkColorClass: 'dark:text-finza-red',
     icon: AlertTriangle,
     label: 'notificaciones.urgente',
+    textColor: 'var(--danger)',
   },
   informativa: {
-    color: 'var(--accent)',
-    bgColor: 'var(--accent)',
-    darkColorClass: 'dark:text-finza-blue',
     icon: Info,
     label: 'notificaciones.informativa',
+    textColor: 'var(--accent)',
   },
   logro: {
-    color: 'var(--success)',
-    bgColor: 'var(--success)',
-    darkColorClass: 'dark:text-finza-green',
     icon: Trophy,
     label: 'notificaciones.logro',
+    textColor: 'var(--success)',
   },
   advertencia: {
-    color: '#E65100',
-    bgColor: '#E65100',
-    darkColorClass: 'dark:text-finza-yellow',
     icon: Bell,
     label: 'notificaciones.advertencia',
+    textColor: '#E65100',
   },
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const date = new Date(dateStr)
+  return date.toLocaleDateString('es-MX', {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 function NotificacionItem({
@@ -58,76 +67,52 @@ function NotificacionItem({
   onEliminar: (id: string) => void
 }): JSX.Element {
   const { t } = useTranslation()
-  const config = TIPO_CONFIG[notificacion.tipo] ?? TIPO_CONFIG.informativa
-  const Icon = config.icon
-
-  const dateStr = new Date(notificacion.created_at).toLocaleDateString('es-MX', {
-    day: 'numeric',
-    month: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  const dotColor = DOT_COLOR[notificacion.tipo] ?? '#3d8ef8'
+  const timeAgo = formatTimeAgo(notificacion.created_at)
 
   return (
     <div
       className={cn(
-        'card-glass p-4 flex items-start gap-3 transition-opacity dark:hover:bg-white/[0.03]',
+        'flex items-start gap-3 p-[14px] rounded-xl border border-[rgba(255,255,255,0.06)]',
+        'bg-[rgba(8,15,30,0.4)] hover:bg-[rgba(8,15,30,0.7)] hover:border-[rgba(255,255,255,0.1)]',
+        'transition-all duration-150 cursor-pointer mb-2',
         notificacion.leida && 'opacity-60'
       )}
     >
-      {/* Tipo icon */}
+      {/* Dot 8px */}
       <div
-        className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
-        style={{ backgroundColor: `${config.bgColor}22` }}
-      >
-        <Icon size={16} style={{ color: config.color }} />
-      </div>
+        className="w-2 h-2 rounded-full flex-shrink-0 mt-[3px]"
+        style={{ backgroundColor: dotColor }}
+      />
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
-            <p
-              className={cn(
-                'text-sm font-semibold',
-                notificacion.leida
-                  ? 'text-[var(--text-muted)]'
-                  : 'text-[var(--text-primary)]'
-              )}
-            >
-              {notificacion.titulo}
-            </p>
-            <p className="text-xs text-[var(--text-muted)] mt-0.5">{notificacion.mensaje}</p>
-            <p className="text-[10px] text-[var(--text-muted)] mt-1.5">{dateStr}</p>
-          </div>
-
-          {/* Tipo badge */}
-          <span
-            className="shrink-0 text-[10px] font-bold px-2 py-0.5 rounded-full"
-            style={{ color: config.color, backgroundColor: `${config.bgColor}22` }}
-          >
-            {t(config.label)}
-          </span>
-        </div>
+        <p className="text-[13px] font-semibold text-[var(--text-primary)] mb-[2px]">
+          {notificacion.titulo}
+        </p>
+        <p className="text-[12px] text-[#657a9e] leading-[1.5]">
+          {notificacion.mensaje}
+        </p>
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-1 shrink-0">
+      {/* Timestamp + actions */}
+      <div className="flex items-start gap-1 flex-shrink-0">
+        <span className="text-[11px] text-[#657a9e]">{timeAgo}</span>
         {!notificacion.leida && (
           <button
-            onClick={() => onLeer(notificacion.id)}
-            className="w-7 h-7 rounded-lg flex items-center justify-center text-[var(--text-muted)] hover:text-[var(--success)] hover:bg-surface-raised transition-colors"
+            onClick={(e) => { e.stopPropagation(); onLeer(notificacion.id) }}
+            className="w-6 h-6 rounded-lg flex items-center justify-center text-[var(--text-muted)] hover:text-[var(--success)] hover:bg-surface-raised transition-colors"
             title={t('notificaciones.markRead')}
           >
-            <CheckCheck size={14} />
+            <CheckCheck size={12} />
           </button>
         )}
         <button
-          onClick={() => onEliminar(notificacion.id)}
-          className="w-7 h-7 rounded-lg flex items-center justify-center text-[var(--text-muted)] hover:text-[var(--danger)] hover:bg-surface-raised transition-colors"
+          onClick={(e) => { e.stopPropagation(); onEliminar(notificacion.id) }}
+          className="w-6 h-6 rounded-lg flex items-center justify-center text-[var(--text-muted)] hover:text-[var(--danger)] hover:bg-surface-raised transition-colors"
           title={t('common.delete')}
         >
-          <Trash2 size={14} />
+          <Trash2 size={12} />
         </button>
       </div>
     </div>
@@ -230,11 +215,14 @@ export function NotificacionesPage(): JSX.Element {
       {/* Urgentes */}
       {urgentes.length > 0 && (
         <section className="mb-5">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--danger)] mb-3 flex items-center gap-1.5">
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-1.5"
+            style={{ color: SECTION_CONFIG.urgente.textColor }}
+          >
             <AlertTriangle size={12} />
-            {t('notificaciones.urgente')}
+            {t(SECTION_CONFIG.urgente.label)}
           </h2>
-          <div className="space-y-2">
+          <div>
             {urgentes.map((n) => (
               <NotificacionItem
                 key={n.id}
@@ -250,11 +238,14 @@ export function NotificacionesPage(): JSX.Element {
       {/* Advertencias */}
       {advertencias.length > 0 && (
         <section className="mb-5">
-          <h2 className="text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-1.5" style={{ color: '#E65100' }}>
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-1.5"
+            style={{ color: SECTION_CONFIG.advertencia.textColor }}
+          >
             <Bell size={12} />
-            {t('notificaciones.advertencia')}
+            {t(SECTION_CONFIG.advertencia.label)}
           </h2>
-          <div className="space-y-2">
+          <div>
             {advertencias.map((n) => (
               <NotificacionItem
                 key={n.id}
@@ -270,11 +261,14 @@ export function NotificacionesPage(): JSX.Element {
       {/* Logros */}
       {logros.length > 0 && (
         <section className="mb-5">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--success)] mb-3 flex items-center gap-1.5">
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-1.5"
+            style={{ color: SECTION_CONFIG.logro.textColor }}
+          >
             <Trophy size={12} />
-            {t('notificaciones.logro')}
+            {t(SECTION_CONFIG.logro.label)}
           </h2>
-          <div className="space-y-2">
+          <div>
             {logros.map((n) => (
               <NotificacionItem
                 key={n.id}
@@ -290,11 +284,14 @@ export function NotificacionesPage(): JSX.Element {
       {/* Informativas */}
       {informativas.length > 0 && (
         <section className="mb-5">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-[var(--accent)] mb-3 flex items-center gap-1.5">
+          <h2
+            className="text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-1.5"
+            style={{ color: SECTION_CONFIG.informativa.textColor }}
+          >
             <Info size={12} />
-            {t('notificaciones.informativa')}
+            {t(SECTION_CONFIG.informativa.label)}
           </h2>
-          <div className="space-y-2">
+          <div>
             {informativas.map((n) => (
               <NotificacionItem
                 key={n.id}

--- a/frontend/src/pages/PresupuestosPage.tsx
+++ b/frontend/src/pages/PresupuestosPage.tsx
@@ -362,11 +362,14 @@ export function PresupuestosPage(): JSX.Element {
               <button
                 type="button"
                 onClick={handleOpenCreate}
-                className="border-2 border-dashed border-white/[0.1] rounded-[20px] flex flex-col items-center justify-center gap-2 text-[#657a9e] cursor-pointer min-h-[160px] hover:border-[#3d8ef8] hover:text-[#3d8ef8] hover:bg-[rgba(61,142,248,0.04)] transition-all"
+                className="border-2 border-dashed border-[#1f2e45] rounded-[20px] min-h-[140px] w-full
+                           flex flex-col items-center justify-center gap-2 text-[#657a9e]
+                           hover:border-[#3d8ef8] hover:text-[#3d8ef8] hover:bg-[rgba(61,142,248,0.04)]
+                           transition-all duration-200 cursor-pointer"
                 aria-label="Nuevo presupuesto"
               >
-                <span className="text-3xl leading-none">+</span>
-                <span className="text-sm font-medium">Nuevo presupuesto</span>
+                <span className="text-[28px] leading-none">+</span>
+                <span className="text-[13px] font-medium">Nuevo presupuesto</span>
               </button>
             )}
           </div>

--- a/frontend/src/pages/__tests__/ConfiguracionPage.test.tsx
+++ b/frontend/src/pages/__tests__/ConfiguracionPage.test.tsx
@@ -119,10 +119,10 @@ describe('ConfiguracionPage', () => {
     expect(screen.getByText('settings.darkMode')).toBeInTheDocument()
   })
 
-  it('clicking dark mode card calls setTheme with dark', () => {
+  it('clicking dark mode toggle calls setTheme with dark', () => {
     renderPage()
     fireEvent.click(screen.getByText('settings.appearance'))
-    fireEvent.click(screen.getByText('settings.darkMode'))
+    fireEvent.click(screen.getByLabelText('Toggle modo oscuro'))
     expect(mockSetTheme).toHaveBeenCalledWith('dark')
   })
 


### PR DESCRIPTION
## Cambios
- **Fondo Emergencia**: hero card full-width con gradient verde/cyan, monto 42px extrabold, progress bar 8px green→cyan, 2 info cards (aportacion en amarillo, meta en azul), botones con gradient green + ghost border
- **Presupuestos**: placeholder con borde dashed border-[#1f2e45], min-h-[140px], text-[28px], hover accent azul — BudgetProgressBar ajustado a h-[6px]
- **Metas**: KPI cards sin border-l-4 de color — borde neutro rgba(255,255,255,0.06), colores solo en los valores
- **Notificaciones**: icono grande 8x8 reemplazado por dot 8px colorido por tipo (urgente→rojo, logro→verde, informativa→azul, advertencia→amarillo), timestamp a la derecha, badge pill eliminado del item
- **Configuracion Apariencia**: tarjetas grandes reemplazadas por config-rows con toggle switch pill w-[42px] h-6

## Stats Bar
No habia icono extra antes de la campanita — ya estaba limpio, fix no aplicaba.

## Tests
- 464 tests passing (44 archivos) — sin regresiones
- ConfiguracionPage test actualizado: getByLabelText en lugar de getByText para el toggle

## Archivos modificados
- `frontend/src/pages/FondoEmergenciaPage.tsx`
- `frontend/src/pages/PresupuestosPage.tsx`
- `frontend/src/pages/NotificacionesPage.tsx`
- `frontend/src/pages/ConfiguracionPage.tsx`
- `frontend/src/pages/__tests__/ConfiguracionPage.test.tsx`
- `frontend/src/features/metas/components/MetasResumenCards.tsx`
- `frontend/src/features/presupuestos/components/BudgetProgressBar.tsx`

Generated with Claude Code