### PR TITLE
fix(push): corregir Uint8Array<ArrayBuffer> para build Docker - TypeScript 5.x

### DIFF
--- a/frontend/src/hooks/usePushNotifications.ts
+++ b/frontend/src/hooks/usePushNotifications.ts
@@ -5,11 +5,11 @@ import { apiClient } from '@/lib/api'
 const VAPID_KEY_ENDPOINT = '/notificaciones/vapid-public-key'
 const SUBSCRIBE_ENDPOINT = '/notificaciones/subscribe'
 
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
   const rawData = window.atob(base64)
-  return new Uint8Array([...rawData].map((c) => c.charCodeAt(0)))
+  return new Uint8Array([...rawData].map((c) => c.charCodeAt(0))) as Uint8Array<ArrayBuffer>
 }
 
 export function usePushNotifications() {


### PR DESCRIPTION
## Problema
Build Docker fallaba en frontend con error TS2322 en `usePushNotifications.ts:54`.

TypeScript 5.x hizo `Uint8Array` genérico — tipo por defecto `ArrayBufferLike` no es assignable a `BufferSource` que requiere `ArrayBuffer` estricto.

## Fix
- Tipo de retorno: `Uint8Array` → `Uint8Array<ArrayBuffer>`
- Cast explícito: `as Uint8Array<ArrayBuffer>`
- `tsc --noEmit` pasa sin errores ✅

**Archivo**: `frontend/src/hooks/usePushNotifications.ts`